### PR TITLE
Add data support for stubbed error responses.

### DIFF
--- a/Demo/DemoTests/MoyaProviderSpec.swift
+++ b/Demo/DemoTests/MoyaProviderSpec.swift
@@ -191,6 +191,19 @@ class MoyaProviderSpec: QuickSpec {
                         let sampleData = target.sampleData as NSData
                         expect{errored}.toEventually(beTruthy(), timeout: 1, pollInterval: 0.1)
                     }
+                    
+                    it("returns stubbed error data when present") {
+                        var errorMessage = ""
+                        
+                        let target: GitHub = .UserProfile("ashfurrow")
+                        provider.request(target, completion: { (object, statusCode, response, error) in
+                            if let object = object {
+                                errorMessage = NSString(data: object, encoding: NSUTF8StringEncoding)!
+                            }
+                        })
+
+                        expect{errorMessage}.toEventually(equal("Houston, we have a problem"), timeout: 1, pollInterval: 0.1)
+                    }
                 })
                 
                 describe("a reactive provider", { () -> () in

--- a/Demo/DemoTests/TestResources.swift
+++ b/Demo/DemoTests/TestResources.swift
@@ -53,5 +53,6 @@ let endpointsClosure = { (target: GitHub, method: Moya.Method, parameters: [Stri
 }
 
 let failureEndpointsClosure = { (target: GitHub, method: Moya.Method, parameters: [String: AnyObject]) -> Endpoint<GitHub> in
-    return Endpoint<GitHub>(URL: url(target), sampleResponse: .Error(401, NSError(domain: "com.moya.error", code: 0, userInfo: nil)), method: method, parameters: parameters)
+    let errorData = "Houston, we have a problem".dataUsingEncoding(NSUTF8StringEncoding)!
+    return Endpoint<GitHub>(URL: url(target), sampleResponse: .Error(401, NSError(domain: "com.moya.error", code: 0, userInfo: nil), errorData), method: method, parameters: parameters)
 }

--- a/Endpoint.swift
+++ b/Endpoint.swift
@@ -12,7 +12,7 @@ import Alamofire
 /// Used for stubbing responses.
 public enum EndpointSampleResponse {
     case Success(Int, NSData)
-    case Error(Int?, NSError?)
+    case Error(Int?, NSError?, NSData?)
 }
 
 /// Class for reifying a target of the T enum unto a concrete Endpoint

--- a/Moya.swift
+++ b/Moya.swift
@@ -118,8 +118,8 @@ public class MoyaProvider<T: MoyaTarget> {
             switch endpoint.sampleResponse {
             case .Success(let statusCode, let data):
                 completion(data: data, statusCode: statusCode, response:nil, error: nil)
-            case .Error(let statusCode, let error):
-                completion(data: nil, statusCode: statusCode, response:nil, error: error)
+            case .Error(let statusCode, let error, let data):
+                completion(data: data, statusCode: statusCode, response:nil, error: error)
             }
         } else {
              Alamofire.Manager.sharedInstance.request(request)


### PR DESCRIPTION
This PR adds the ability to stub data when testing errors. In production many of our errors have structured data. This allows unit tests to account for them. (Thanks for all the hard work on Moya, we are very happy with it so far.) 