### PR TITLE
[WIP] Adds 'Lazy' type, so sampleData can be requested later

### DIFF
--- a/Demo/DemoTests/EndpointSpec.swift
+++ b/Demo/DemoTests/EndpointSpec.swift
@@ -30,7 +30,7 @@ public func ==(lhs: Moya.ParameterEncoding, rhs: Moya.ParameterEncoding) -> Bool
 
 class EndpointSpec: QuickSpec {
     override func spec() {
-        describe("an enpoint", { () -> () in
+        describe("an endpoint", { () -> () in
             var endpoint: Endpoint<GitHub>!
             
             beforeEach({ () -> () in

--- a/Demo/DemoTests/MoyaProviderIntegrationTests.swift
+++ b/Demo/DemoTests/MoyaProviderIntegrationTests.swift
@@ -20,7 +20,7 @@ func beIndenticalToResponse(expectedValue: MoyaResponse) -> MatcherFunc<MoyaResp
 
 class MoyaProviderIntegrationTests: QuickSpec {
     override func spec() {
-        describe("valid enpoints") {
+        describe("valid endpoints") {
             describe("with live data") {
                 describe("a provider", { () -> () in
                     var provider: MoyaProvider<GitHub>!

--- a/Demo/DemoTests/MoyaProviderSpec.swift
+++ b/Demo/DemoTests/MoyaProviderSpec.swift
@@ -57,6 +57,27 @@ class MoyaProviderSpec: QuickSpec {
                     }
                 })
 
+                describe("a provider with lazy data", { () -> () in
+                    var provider: MoyaProvider<GitHub>!
+                    beforeEach {
+                        provider = MoyaProvider(endpointsClosure: lazyEndpointsClosure, stubResponses: true)
+                    }
+
+                    it("returns stubbed data for zen request") {
+                        var message: String?
+
+                        let target: GitHub = .Zen
+                        provider.request(target, completion: { (data, statusCode, response, error) in
+                            if let data = data {
+                                message = NSString(data: data, encoding: NSUTF8StringEncoding)
+                            }
+                        })
+
+                        let sampleData = target.sampleData as NSData
+                        expect(message).to(equal(NSString(data: sampleData, encoding: NSUTF8StringEncoding)))
+                    }
+                })
+
                 it("delays execution when appropriate") {
                     let closure = { (target: GitHub) -> (Moya.StubbedBehavior) in
                         return .Delayed(seconds: 2)

--- a/Demo/DemoTests/MoyaProviderSpec.swift
+++ b/Demo/DemoTests/MoyaProviderSpec.swift
@@ -12,7 +12,7 @@ import Nimble
 
 class MoyaProviderSpec: QuickSpec {
     override func spec() {
-        describe("valid enpoints") {
+        describe("valid endpoints") {
             describe("with stubbed responses") {
                 describe("a provider", { () -> () in
                     var provider: MoyaProvider<GitHub>!

--- a/Demo/DemoTests/TestResources.swift
+++ b/Demo/DemoTests/TestResources.swift
@@ -52,6 +52,10 @@ let endpointsClosure = { (target: GitHub, method: Moya.Method, parameters: [Stri
     return Endpoint<GitHub>(URL: url(target), sampleResponse: .Success(200, target.sampleData), method: method, parameters: parameters)
 }
 
+let lazyEndpointsClosure = { (target: GitHub, method: Moya.Method, parameters: [String: AnyObject]) -> Endpoint<GitHub> in
+    return Endpoint<GitHub>(URL: url(target), sampleResponse: .Closure(.Success(200, target.sampleData)), method: method, parameters: parameters)
+}
+
 let failureEndpointsClosure = { (target: GitHub, method: Moya.Method, parameters: [String: AnyObject]) -> Endpoint<GitHub> in
     let errorData = "Houston, we have a problem".dataUsingEncoding(NSUTF8StringEncoding)!
     return Endpoint<GitHub>(URL: url(target), sampleResponse: .Error(401, NSError(domain: "com.moya.error", code: 0, userInfo: nil), errorData), method: method, parameters: parameters)

--- a/Endpoint.swift
+++ b/Endpoint.swift
@@ -11,17 +11,8 @@ import Alamofire
 
 /// Used for stubbing responses.
 public enum EndpointSampleResponse {
-    case Success(Int, NSData)
-    case Error(Int?, NSError?, NSData?)
-    case Lazy(()-> EndpointSampleResponse)
-
-    func evaluate() -> EndpointSampleResponse {
-        switch self {
-        case Success, Error: return self
-        case Lazy(let lazy):
-            return lazy().evaluate()
-        }
-    }
+    case Success(@autoclosure () -> (Int, NSData))
+    case Error(@autoclosure () -> (Int?, NSError?, NSData?))
 }
 
 

--- a/Endpoint.swift
+++ b/Endpoint.swift
@@ -11,8 +11,8 @@ import Alamofire
 
 /// Used for stubbing responses.
 public enum EndpointSampleResponse {
-    case Success(@autoclosure () -> (Int, NSData))
-    case Error(@autoclosure () -> (Int?, NSError?, NSData?))
+    case Success(@autoclosure () -> Int, @autoclosure () -> NSData)
+    case Error(@autoclosure () -> Int?, @autoclosure () -> NSError?, @autoclosure () -> NSData?)
 }
 
 

--- a/Endpoint.swift
+++ b/Endpoint.swift
@@ -11,8 +11,17 @@ import Alamofire
 
 /// Used for stubbing responses.
 public enum EndpointSampleResponse {
-    case Success(@autoclosure () -> Int, @autoclosure () -> NSData)
-    case Error(@autoclosure () -> Int?, @autoclosure () -> NSError?, @autoclosure () -> NSData?)
+    case Success(Int, NSData)
+    case Error(Int?, NSError?, NSData?)
+    case Closure(@autoclosure () -> EndpointSampleResponse)
+
+    func evaluate() -> EndpointSampleResponse {
+        switch self {
+        case Success, Error: return self
+        case Closure(let closure):
+            return closure().evaluate()
+        }
+    }
 }
 
 

--- a/Endpoint.swift
+++ b/Endpoint.swift
@@ -13,7 +13,17 @@ import Alamofire
 public enum EndpointSampleResponse {
     case Success(Int, NSData)
     case Error(Int?, NSError?, NSData?)
+    case Lazy(()-> EndpointSampleResponse)
+
+    func evaluate() -> EndpointSampleResponse {
+        switch self {
+        case Success, Error: return self
+        case Lazy(let lazy):
+            return lazy().evaluate()
+        }
+    }
 }
+
 
 /// Class for reifying a target of the T enum unto a concrete Endpoint
 public class Endpoint<T> {

--- a/Moya.swift
+++ b/Moya.swift
@@ -126,13 +126,19 @@ public class MoyaProvider<T: MoyaTarget> {
             let behavior = stubBehavior(token)
 
             let stub: () -> () = {
-                switch endpoint.sampleResponse.evaluate() {
-                case .Success(let statusCode, let data):
+                var statusCode : Int
+                var data : NSData
+                var optStatusCode : Int?
+                var optData : NSData?
+                var optError : NSError?
+
+                switch endpoint.sampleResponse {
+                case .Success(let successClosure):
+                    (statusCode, data) = successClosure()
                     completion(data: data, statusCode: statusCode, response:nil, error: nil)
-                case .Error(let statusCode, let error, let data):
-                    completion(data: data, statusCode: statusCode, response:nil, error: error)
-                default:
-                    Void()  // evaluate will always return Success or Error, but exhaustive switches and all that...
+                case .Error(let failureClosure):
+                    (optStatusCode, optError, optData) = failureClosure()
+                    completion(data: optData, statusCode: optStatusCode, response:nil, error: optError)
                 }
             }
 

--- a/Moya.swift
+++ b/Moya.swift
@@ -121,16 +121,18 @@ public class MoyaProvider<T: MoyaTarget> {
     public func request(token: T, method: Moya.Method, parameters: [String: AnyObject], completion: MoyaCompletion) {
         let endpoint = self.endpoint(token, method: method, parameters: parameters)
         let request = endpointResolver(endpoint: endpoint)
-        
-        if (stubResponses) {
+
+        if stubResponses {
             let behavior = stubBehavior(token)
 
             let stub: () -> () = {
-                switch endpoint.sampleResponse {
-                case .Success(let statusCodeClosure, let dataClosure):
-                    completion(data: dataClosure(), statusCode: statusCodeClosure(), response:nil, error: nil)
-                case .Error(let statusCodeClosure, let errorClosure, let dataClosure):
-                    completion(data: dataClosure(), statusCode: statusCodeClosure(), response:nil, error: errorClosure())
+                switch endpoint.sampleResponse.evaluate() {
+                    case .Success(let statusCode, let data):
+                        completion(data: data, statusCode: statusCode, response:nil, error: nil)
+                    case .Error(let statusCode, let error, let data):
+                        completion(data: data, statusCode: statusCode, response:nil, error: error)
+                    case .Closure:
+                        break  // the `evaluate()` method will never actually return a .Closure
                 }
             }
 

--- a/Moya.swift
+++ b/Moya.swift
@@ -126,11 +126,13 @@ public class MoyaProvider<T: MoyaTarget> {
             let behavior = stubBehavior(token)
 
             let stub: () -> () = {
-                switch endpoint.sampleResponse {
+                switch endpoint.sampleResponse.evaluate() {
                 case .Success(let statusCode, let data):
                     completion(data: data, statusCode: statusCode, response:nil, error: nil)
                 case .Error(let statusCode, let error, let data):
                     completion(data: data, statusCode: statusCode, response:nil, error: error)
+                default:
+                    Void()  // evaluate will always return Success or Error, but exhaustive switches and all that...
                 }
             }
 

--- a/Moya.swift
+++ b/Moya.swift
@@ -126,12 +126,6 @@ public class MoyaProvider<T: MoyaTarget> {
             let behavior = stubBehavior(token)
 
             let stub: () -> () = {
-                var statusCode : Int
-                var data : NSData
-                var optStatusCode : Int?
-                var optData : NSData?
-                var optError : NSError?
-
                 switch endpoint.sampleResponse {
                 case .Success(let statusCodeClosure, let dataClosure):
                     completion(data: dataClosure(), statusCode: statusCodeClosure(), response:nil, error: nil)

--- a/Moya.swift
+++ b/Moya.swift
@@ -133,12 +133,10 @@ public class MoyaProvider<T: MoyaTarget> {
                 var optError : NSError?
 
                 switch endpoint.sampleResponse {
-                case .Success(let successClosure):
-                    (statusCode, data) = successClosure()
-                    completion(data: data, statusCode: statusCode, response:nil, error: nil)
-                case .Error(let failureClosure):
-                    (optStatusCode, optError, optData) = failureClosure()
-                    completion(data: optData, statusCode: optStatusCode, response:nil, error: optError)
+                case .Success(let statusCodeClosure, let dataClosure):
+                    completion(data: dataClosure(), statusCode: statusCodeClosure(), response:nil, error: nil)
+                case .Error(let statusCodeClosure, let errorClosure, let dataClosure):
+                    completion(data: dataClosure(), statusCode: statusCodeClosure(), response:nil, error: errorClosure())
                 }
             }
 


### PR DESCRIPTION
I'm having trouble getting the specs to run... also, if you think this PR is worthwhile, I would like to add some specs around this specific feature.  Let me know what you think!

Example:

```swift
let endpointsClosure = { (target: GitHub, method: Moya.Method, parameters: [String: AnyObject]) -> Endpoint<GitHub> in
    return Endpoint<GitHub>(URL: url(target), method: method, parameters: parameters,
        sampleResponse: .Lazy({ return .Success(200, target.sampleDataFromSomeExpensiveOperation) })
    )
}
```
