### PR TITLE
[WIP] swift 1.2 support

### DIFF
--- a/Endpoint.swift
+++ b/Endpoint.swift
@@ -13,7 +13,7 @@ import Alamofire
 public enum EndpointSampleResponse {
     case Success(Int, NSData)
     case Error(Int?, NSError?, NSData?)
-    case Closure(@autoclosure () -> EndpointSampleResponse)
+    case Closure(() -> EndpointSampleResponse)
 
     func evaluate() -> EndpointSampleResponse {
         switch self {

--- a/Moya+ReactiveCocoa.swift
+++ b/Moya+ReactiveCocoa.swift
@@ -38,8 +38,8 @@ public class ReactiveMoyaProvider<T where T: MoyaTarget>: MoyaProvider<T> {
     public var inflightRequests = Dictionary<Endpoint<T>, RACSignal>()
     
     /// Initializes a reactive provider.
-    override public init(endpointsClosure: MoyaEndpointsClosure, endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEnpointResolution(), stubResponses: Bool = false, stubBehavior: MoyaStubbedBehavior? = MoyaProvider.DefaultStubBehavior) {
-        super.init(endpointsClosure: endpointsClosure, endpointResolver: endpointResolver, stubResponses: stubResponses)
+    override public init(endpointsClosure: MoyaEndpointsClosure, endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEnpointResolution(), stubResponses: Bool  = false, stubBehavior: MoyaStubbedBehavior = MoyaProvider.DefaultStubBehavior) {
+        super.init(endpointsClosure: endpointsClosure, endpointResolver: endpointResolver, stubResponses: stubResponses, stubBehavior: stubBehavior)
     }
     
     /// Designated request-making method.

--- a/Moya.swift
+++ b/Moya.swift
@@ -163,15 +163,15 @@ public class MoyaProvider<T: MoyaTarget> {
     }
     
     public func request(token: T, parameters: [String: AnyObject], completion: MoyaCompletion) {
-        request(token, method: Moya.DefaultMethod(), parameters: parameters, completion)
+        request(token, method: Moya.DefaultMethod(), parameters: parameters, completion: completion)
     }
 
     public func request(token: T, method: Moya.Method, completion: MoyaCompletion) {
-        request(token, method: method, parameters: Moya.DefaultParameters(), completion)
+        request(token, method: method, parameters: Moya.DefaultParameters(), completion: completion)
     }
     
     public func request(token: T, completion: MoyaCompletion) {
-        request(token, method: Moya.DefaultMethod(), completion)
+        request(token, method: Moya.DefaultMethod(), completion: completion)
     }
     
     public class func DefaultEnpointResolution() -> MoyaEndpointResolution {

--- a/RACSignal+Moya.swift
+++ b/RACSignal+Moya.swift
@@ -100,7 +100,7 @@ public extension RACSignal {
             var string: String?
             
             if let response = object as? MoyaResponse {
-                string = NSString(data: response.data, encoding: NSUTF8StringEncoding)
+                string = NSString(data: response.data, encoding: NSUTF8StringEncoding) as? String
             }
             
             if string == nil {


### PR DESCRIPTION
For now, this only updates the swift files to work with 1.2. The ReactiveCocoa dependencies still need to be updated. This requires a .podspec for ReactiveCocoa 3.0 alpha 3.