### PR TITLE
Adding iOS dynamic framework with project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,9 @@ DerivedData
 # CocoaPods
 Pods
 
+# Carthage
+Carthage/Checkouts
+Carthage/Builds
+
 # AppCode
 .idea/

--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,2 @@
+github "ReactiveCocoa/ReactiveCocoa" "v3.0-beta.4"
+github "Alamofire/Alamofire" ~> 1.2.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,0 +1,4 @@
+github "Alamofire/Alamofire" "1.2.2"
+github "robrix/Box" "1.2.2"
+github "antitypical/Result" "0.4.2"
+github "ReactiveCocoa/ReactiveCocoa" "1c8b18751c4af1f3c6003077ff57bed80e184c3a"

--- a/Moya.xcodeproj/project.pbxproj
+++ b/Moya.xcodeproj/project.pbxproj
@@ -1,0 +1,331 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		BF7424E21B0401C70086929D /* Moya.h in Headers */ = {isa = PBXBuildFile; fileRef = BF7424E11B0401C70086929D /* Moya.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BF7424FC1B04025C0086929D /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7424F81B04025C0086929D /* Endpoint.swift */; };
+		BF7424FD1B04025C0086929D /* Moya.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7424F91B04025C0086929D /* Moya.swift */; };
+		BF7424FE1B04025C0086929D /* Moya+ReactiveCocoa.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7424FA1B04025C0086929D /* Moya+ReactiveCocoa.swift */; };
+		BF7424FF1B04025C0086929D /* RACSignal+Moya.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7424FB1B04025C0086929D /* RACSignal+Moya.swift */; };
+		BF7425021B04045D0086929D /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF7425001B04045D0086929D /* Alamofire.framework */; };
+		BF7425031B04045D0086929D /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF7425011B04045D0086929D /* ReactiveCocoa.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		BF7424DC1B0401C70086929D /* Moya.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Moya.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		BF7424E01B0401C70086929D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		BF7424E11B0401C70086929D /* Moya.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Moya.h; sourceTree = "<group>"; };
+		BF7424F81B04025C0086929D /* Endpoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Endpoint.swift; sourceTree = SOURCE_ROOT; };
+		BF7424F91B04025C0086929D /* Moya.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Moya.swift; sourceTree = SOURCE_ROOT; };
+		BF7424FA1B04025C0086929D /* Moya+ReactiveCocoa.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Moya+ReactiveCocoa.swift"; sourceTree = SOURCE_ROOT; };
+		BF7424FB1B04025C0086929D /* RACSignal+Moya.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "RACSignal+Moya.swift"; sourceTree = SOURCE_ROOT; };
+		BF7425001B04045D0086929D /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Alamofire.framework; path = Carthage/Build/iOS/Alamofire.framework; sourceTree = "<group>"; };
+		BF7425011B04045D0086929D /* ReactiveCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveCocoa.framework; path = Carthage/Build/iOS/ReactiveCocoa.framework; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		BF7424D81B0401C70086929D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF7425021B04045D0086929D /* Alamofire.framework in Frameworks */,
+				BF7425031B04045D0086929D /* ReactiveCocoa.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		BF7424D21B0401C70086929D = {
+			isa = PBXGroup;
+			children = (
+				BF7424DE1B0401C70086929D /* Moya */,
+				BF7425041B0404BE0086929D /* Frameworks */,
+				BF7424DD1B0401C70086929D /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		BF7424DD1B0401C70086929D /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				BF7424DC1B0401C70086929D /* Moya.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		BF7424DE1B0401C70086929D /* Moya */ = {
+			isa = PBXGroup;
+			children = (
+				BF7424E11B0401C70086929D /* Moya.h */,
+				BF7424F81B04025C0086929D /* Endpoint.swift */,
+				BF7424F91B04025C0086929D /* Moya.swift */,
+				BF7424FA1B04025C0086929D /* Moya+ReactiveCocoa.swift */,
+				BF7424FB1B04025C0086929D /* RACSignal+Moya.swift */,
+				BF7424DF1B0401C70086929D /* Supporting Files */,
+			);
+			path = Moya;
+			sourceTree = "<group>";
+		};
+		BF7424DF1B0401C70086929D /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				BF7424E01B0401C70086929D /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		BF7425041B0404BE0086929D /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				BF7425001B04045D0086929D /* Alamofire.framework */,
+				BF7425011B04045D0086929D /* ReactiveCocoa.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		BF7424D91B0401C70086929D /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF7424E21B0401C70086929D /* Moya.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		BF7424DB1B0401C70086929D /* Moya iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BF7424F21B0401C70086929D /* Build configuration list for PBXNativeTarget "Moya iOS" */;
+			buildPhases = (
+				BF7424D71B0401C70086929D /* Sources */,
+				BF7424D81B0401C70086929D /* Frameworks */,
+				BF7424D91B0401C70086929D /* Headers */,
+				BF7424DA1B0401C70086929D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Moya iOS";
+			productName = Moya;
+			productReference = BF7424DC1B0401C70086929D /* Moya.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		BF7424D31B0401C70086929D /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0640;
+				TargetAttributes = {
+					BF7424DB1B0401C70086929D = {
+						CreatedOnToolsVersion = 6.3.2;
+					};
+				};
+			};
+			buildConfigurationList = BF7424D61B0401C70086929D /* Build configuration list for PBXProject "Moya" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = BF7424D21B0401C70086929D;
+			productRefGroup = BF7424DD1B0401C70086929D /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				BF7424DB1B0401C70086929D /* Moya iOS */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		BF7424DA1B0401C70086929D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		BF7424D71B0401C70086929D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF7424FF1B04025C0086929D /* RACSignal+Moya.swift in Sources */,
+				BF7424FE1B04025C0086929D /* Moya+ReactiveCocoa.swift in Sources */,
+				BF7424FC1B04025C0086929D /* Endpoint.swift in Sources */,
+				BF7424FD1B04025C0086929D /* Moya.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		BF7424F01B0401C70086929D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		BF7424F11B0401C70086929D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		BF7424F31B0401C70086929D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = Moya/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(PROJECT_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		BF7424F41B0401C70086929D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = Moya/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(PROJECT_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		BF7424D61B0401C70086929D /* Build configuration list for PBXProject "Moya" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BF7424F01B0401C70086929D /* Debug */,
+				BF7424F11B0401C70086929D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		BF7424F21B0401C70086929D /* Build configuration list for PBXNativeTarget "Moya iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BF7424F31B0401C70086929D /* Debug */,
+				BF7424F41B0401C70086929D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = BF7424D31B0401C70086929D /* Project object */;
+}

--- a/Moya.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Moya.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:Moya.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Moya.xcodeproj/xcshareddata/xcschemes/Moya.xcscheme
+++ b/Moya.xcodeproj/xcshareddata/xcschemes/Moya.xcscheme
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0630"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BF7424DB1B0401C70086929D"
+               BuildableName = "Moya iOS.framework"
+               BlueprintName = "Moya iOS"
+               ReferencedContainer = "container:Moya.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BF7424E61B0401C70086929D"
+               BuildableName = "MoyaTests.xctest"
+               BlueprintName = "MoyaTests"
+               ReferencedContainer = "container:Moya.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BF7424E61B0401C70086929D"
+               BuildableName = "MoyaTests.xctest"
+               BlueprintName = "MoyaTests"
+               ReferencedContainer = "container:Moya.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BF7424DB1B0401C70086929D"
+            BuildableName = "Moya iOS.framework"
+            BlueprintName = "Moya iOS"
+            ReferencedContainer = "container:Moya.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BF7424DB1B0401C70086929D"
+            BuildableName = "Moya iOS.framework"
+            BlueprintName = "Moya iOS"
+            ReferencedContainer = "container:Moya.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BF7424DB1B0401C70086929D"
+            BuildableName = "Moya iOS.framework"
+            BlueprintName = "Moya iOS"
+            ReferencedContainer = "container:Moya.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Moya/Info.plist
+++ b/Moya/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.ashfurrow.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.7.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/Moya/Moya.h
+++ b/Moya/Moya.h
@@ -1,0 +1,19 @@
+//
+//  Moya.h
+//  Moya
+//
+//  Created by Michael McGuire on 2015-05-13.
+//  Copyright (c) 2014 Ash Furrow. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for Moya.
+FOUNDATION_EXPORT double MoyaVersionNumber;
+
+//! Project version string for Moya.
+FOUNDATION_EXPORT const unsigned char MoyaVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <Moya/PublicHeader.h>
+
+


### PR DESCRIPTION
This pull request does the following:
* Adds a new Moya project at the root with an iOS Dynamic Framework target
    * The project/target are only used for building with Carthage.  The tests and demo are not included.
* Adds a `Cartfile` and `Cartfile.resolved` pointing to ReactiveCocoa and Alamofire as dependencies.
* Updates the `.gitignore` to ignore the `Carthage\Checkouts` and `Carthage\Builds` directory.  

I spent a considerable amount of time trying to add the dynamic framework target to the Demo project, to avoid requiring a separate project.  Ultimately, I think it is doable, but would require the use of submodules for dependencies.  I tried going the route of using a Cartfile, but because the Cartfile wasn't in the root directory, Carthage was failing to take note of the dependencies when I tried including Moya via Carthage.

I've tested via my own fork and I was able to add and build Moya via Carthage.