### PR TITLE
Adding cancelable behavior to MoyaProvider requests

### DIFF
--- a/Demo/DemoTests/MoyaProviderIntegrationTests.swift
+++ b/Demo/DemoTests/MoyaProviderIntegrationTests.swift
@@ -72,7 +72,7 @@ class MoyaProviderIntegrationTests: QuickSpec {
                         expect{message}.toEventually( equal(userMessage) )
                     }
                     
-                    it("returns an error when canceled") {
+                    it("returns an error when cancelled") {
                         var receivedError: NSError?
                         
                         let target: GitHub = .UserProfile("ashfurrow")
@@ -81,7 +81,7 @@ class MoyaProviderIntegrationTests: QuickSpec {
                         }
                         token.cancel()
                         
-                        expect(receivedError).toEventuallyNot(beNil())
+                        expect(receivedError).toEventuallyNot( beNil() )
                     }
                 }
 

--- a/Demo/DemoTests/MoyaProviderIntegrationTests.swift
+++ b/Demo/DemoTests/MoyaProviderIntegrationTests.swift
@@ -71,6 +71,18 @@ class MoyaProviderIntegrationTests: QuickSpec {
                         
                         expect{message}.toEventually( equal(userMessage) )
                     }
+                    
+                    it("returns an error when canceled") {
+                        var receivedError: NSError?
+                        
+                        let target: GitHub = .UserProfile("ashfurrow")
+                        let token = provider.request(target) { (data, statusCode, response, error) in
+                            receivedError = error
+                        }
+                        token.cancel()
+                        
+                        expect(receivedError).toEventuallyNot(beNil())
+                    }
                 }
 
                 describe("a provider with network activity closures") {

--- a/Demo/DemoTests/MoyaProviderSpec.swift
+++ b/Demo/DemoTests/MoyaProviderSpec.swift
@@ -256,6 +256,31 @@ class MoyaProviderSpec: QuickSpec {
                         expect(provider.inflightRequests.count).to(equal(0))
                     }
                 })
+                
+                describe("a reactive provider with delayed stubs") {
+                    var provider: ReactiveMoyaProvider<GitHub>!
+                    beforeEach {
+                        let closure = { (target: GitHub) -> (Moya.StubbedBehavior) in
+                            return .Delayed(seconds: 2)
+                        }
+                        
+                        provider = ReactiveMoyaProvider(endpointsClosure: endpointsClosure, stubResponses: true, stubBehavior: closure)
+                    }
+                    
+                    it("returns canceled error when delayed execution is canceled") {
+                        var receivedError: NSError?
+                        let target: GitHub = .Zen
+                        waitUntil(timeout: 3) { done in
+                            let disposable = provider.request(target).subscribeError { (error) -> Void in
+                                receivedError = error
+                                done()
+                            }
+                            disposable.dispose()
+                        }
+                        
+                        expect(receivedError).toNot(beNil())
+                    }
+                }
             }
             
             describe("with stubbed errors") {

--- a/Demo/DemoTests/MoyaProviderSpec.swift
+++ b/Demo/DemoTests/MoyaProviderSpec.swift
@@ -56,12 +56,12 @@ class MoyaProviderSpec: QuickSpec {
                         expect(endpoint1).to(equal(endpoint2))
                     }
                     
-                    it("returns an cancelable object when a request is made") {
+                    it("returns a cancellable object when a request is made") {
                         let target: GitHub = .UserProfile("ashfurrow")
                         
-                        let cancelable: Cancelable = provider.request(target) { (_, _, _, _) in }
+                        let cancellable: Cancellable = provider.request(target) { (_, _, _, _) in }
                         
-                        expect(cancelable).toNot(beNil())
+                        expect(cancellable).toNot(beNil())
 
                     }
                 })
@@ -138,7 +138,7 @@ class MoyaProviderSpec: QuickSpec {
                     }.to( beGreaterThanOrEqualTo(NSTimeInterval(2)) )
                 }
                 
-                it("returns canceled error when delayed execution is canceled") {
+                it("returns cancelled error when delayed execution is cancelled") {
                     let closure = { (target: GitHub) -> (Moya.StubbedBehavior) in
                         return .Delayed(seconds: 2)
                     }
@@ -147,7 +147,7 @@ class MoyaProviderSpec: QuickSpec {
                     
                     var receivedError: NSError?
                     let target: GitHub = .Zen
-                    waitUntil(timeout: 3) { done in
+                    waitUntil { done in
                         let token = provider.request(target) { (data, statusCode, response, error) in
                             receivedError = error
                             done()
@@ -267,18 +267,18 @@ class MoyaProviderSpec: QuickSpec {
                         provider = ReactiveMoyaProvider(endpointsClosure: endpointsClosure, stubResponses: true, stubBehavior: closure)
                     }
                     
-                    it("returns canceled error when delayed execution is canceled") {
-                        var receivedError: NSError?
+                    it("cancels subscriptions when delayed execution is cancelled") {
+                        var called = false
                         let target: GitHub = .Zen
                         waitUntil(timeout: 3) { done in
-                            let disposable = provider.request(target).subscribeError { (error) -> Void in
-                                receivedError = error
+                            let disposable = provider.request(target).subscribeError { _ -> Void in
+                                called = true
                                 done()
                             }
                             disposable.dispose()
                         }
                         
-                        expect(receivedError).toNot(beNil())
+                        expect(called).to(beFalse())
                     }
                 }
             }

--- a/Moya+ReactiveCocoa.swift
+++ b/Moya+ReactiveCocoa.swift
@@ -56,7 +56,7 @@ public class ReactiveMoyaProvider<T where T: MoyaTarget>: MoyaProvider<T> {
             }
             
             let signal = RACSignal.createSignal({ (subscriber) -> RACDisposable! in
-                let cancelableToken = self?.request(token, method: method, parameters: parameters) { (data, statusCode, response, error) -> () in
+                let cancellableToken = self?.request(token, method: method, parameters: parameters) { (data, statusCode, response, error) -> () in
                     if let error = error {
                         if let statusCode = statusCode {
                             subscriber.sendError(NSError(domain: error.domain, code: statusCode, userInfo: error.userInfo))
@@ -75,7 +75,7 @@ public class ReactiveMoyaProvider<T where T: MoyaTarget>: MoyaProvider<T> {
                     if let weakSelf = self {
                         objc_sync_enter(weakSelf)
                         weakSelf.inflightRequests[endpoint] = nil
-                        cancelableToken?.cancel()
+                        cancellableToken?.cancel()
                         objc_sync_exit(weakSelf)
                     }
                 })

--- a/Moya+ReactiveCocoa.swift
+++ b/Moya+ReactiveCocoa.swift
@@ -56,7 +56,7 @@ public class ReactiveMoyaProvider<T where T: MoyaTarget>: MoyaProvider<T> {
             }
             
             let signal = RACSignal.createSignal({ (subscriber) -> RACDisposable! in
-                self?.request(token, method: method, parameters: parameters) { (data, statusCode, response, error) -> () in
+                let cancelableToken = self?.request(token, method: method, parameters: parameters) { (data, statusCode, response, error) -> () in
                     if let error = error {
                         if let statusCode = statusCode {
                             subscriber.sendError(NSError(domain: error.domain, code: statusCode, userInfo: error.userInfo))
@@ -75,6 +75,7 @@ public class ReactiveMoyaProvider<T where T: MoyaTarget>: MoyaProvider<T> {
                     if let weakSelf = self {
                         objc_sync_enter(weakSelf)
                         weakSelf.inflightRequests[endpoint] = nil
+                        cancelableToken?.cancel()
                         objc_sync_exit(weakSelf)
                     }
                 })

--- a/Moya.swift
+++ b/Moya.swift
@@ -100,18 +100,14 @@ public protocol MoyaTarget : MoyaPath {
 }
 
 /// Protocol to define the opaque type returned from a request
-public protocol Cancelable {
+public protocol Cancellable {
     func cancel()
 }
 
 /// Internal token that can be used to cancel requests
-struct CancelableToken : Cancelable {
+struct CancellableToken : Cancellable {
     
     let cancelAction: () -> ()
-    
-    init(cancelAction: () -> ()) {
-        self.cancelAction = cancelAction
-    }
     
     func cancel() {
         cancelAction()
@@ -147,7 +143,7 @@ public class MoyaProvider<T: MoyaTarget> {
     }
     
     /// Designated request-making method.
-    public func request(token: T, method: Moya.Method, parameters: [String: AnyObject], completion: MoyaCompletion) -> Cancelable {
+    public func request(token: T, method: Moya.Method, parameters: [String: AnyObject], completion: MoyaCompletion) -> Cancellable {
         let endpoint = self.endpoint(token, method: method, parameters: parameters)
         let request = endpointResolver(endpoint: endpoint)
 
@@ -156,7 +152,7 @@ public class MoyaProvider<T: MoyaTarget> {
         if stubResponses {
             
             var canceled = false
-            let cancelableToken = CancelableToken { canceled = true }
+            let cancellableToken = CancellableToken { canceled = true }
             
             let behavior = stubBehavior(token)
 
@@ -189,7 +185,7 @@ public class MoyaProvider<T: MoyaTarget> {
                 }
             }
             
-            return cancelableToken
+            return cancellableToken
 
         } else {
             // We need to keep a reference to the closure without a reference to ourself.
@@ -208,21 +204,21 @@ public class MoyaProvider<T: MoyaTarget> {
                     }
             }
             
-            return CancelableToken {
+            return CancellableToken {
                 request.cancel()
             }
         }
     }
 
-    public func request(token: T, parameters: [String: AnyObject], completion: MoyaCompletion) -> Cancelable {
+    public func request(token: T, parameters: [String: AnyObject], completion: MoyaCompletion) -> Cancellable {
         return request(token, method: Moya.DefaultMethod(), parameters: parameters, completion)
     }
 
-    public func request(token: T, method: Moya.Method, completion: MoyaCompletion) -> Cancelable {
+    public func request(token: T, method: Moya.Method, completion: MoyaCompletion) -> Cancellable {
         return request(token, method: method, parameters: Moya.DefaultParameters(), completion)
     }
     
-    public func request(token: T, completion: MoyaCompletion) -> Cancelable {
+    public func request(token: T, completion: MoyaCompletion) -> Cancellable {
         return request(token, method: Moya.DefaultMethod(), completion)
     }
     


### PR DESCRIPTION
Resolves #119 

* Functionality will only work for delayed stubbed responses and actual network requests
* For stubbed responses, returns an NSError similar to what you get from a real network cancelation

Don't be shy about any feedback. Nitpick away! :bow: