### PR TITLE
Remove redundancy in circle.yml and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ test:
 	set -o pipefail && xcodebuild -workspace '$(WORKSPACE)' -scheme '$(SCHEME)' -configuration Debug test -sdk iphonesimulator -destination 'name=iPhone 5' | xcpretty -c --test
 
 setup:
+	bundle install
 	bundle exec pod install --project-directory=Demo/
 
 prepare_ci:	setup 

--- a/circle.yml
+++ b/circle.yml
@@ -2,11 +2,8 @@ machine:
   xcode:
     version: "6.3.1"
 dependencies:
-  pre:
-    - sudo gem install cocoapods --version 0.37.1
-    - pod setup
-    - cd Demo ; pod install ; cd ..
+  override:
+    - make prepare_ci
 test:
   override:
-    - make setup
-    - make test
+    - make ci


### PR DESCRIPTION
I am not sure if the steps declared in the dependencies section of the `circle.yml` are actually needed, so I removed them and used the `Makefile` (which does kind of the same) instead.