### PR TITLE
Add RxSwift provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
+# 1.1.0
+
+- Adds support for RxSwift
+
 # 1.0.0
 
 -  **Breaking change** Changes `EndpointSampleResponse` to require closures that return `NSData`, not `NSData` instances themselves. This prevents sample data from being loaded during the normal, non-unit test app lifecycle.
-- **Breaking change** Adds `method` to `MoyaTarget` protocol and removes `method` parameter from `request()` functions. Targets now specify GET, POST, etc on a per-target level, instead of per-request. 
+- **Breaking change** Adds `method` to `MoyaTarget` protocol and removes `method` parameter from `request()` functions. Targets now specify GET, POST, etc on a per-target level, instead of per-request.
 - **Breaking change** Adds `parameters` to `MoyaTarget` protocol and removes ability to pass parameters into `request()` functions. Targets now specify the parameters directly on a per-target level, instead of per-request.
 - Adds a sane default implementation of the `MoyaProvider` initializer's `endpointsClosure` parameter.
 
@@ -23,7 +27,7 @@
 
 # 0.6
 
-- First release on CocoaPods trunk. 
+- First release on CocoaPods trunk.
 - Add data support for [stubbed error responses](https://github.com/ashfurrow/Moya/pull/92). – [@steam](http://github.com.steam)
 - Fixes [#66](https://github.com/AshFurrow/Moya/issues/66), a problem with outdated Alamofire dependency and it's serializer type signature. -[@garnett](http://github.com/garnett)
 - Delete note about ReactiveCocoa installation -[@garnett](http://github.com/garnett)

--- a/Demo/DemoTests/MoyaProviderSpec.swift
+++ b/Demo/DemoTests/MoyaProviderSpec.swift
@@ -281,6 +281,23 @@ class MoyaProviderSpec: QuickSpec {
                         expect(receivedResponse).toNot(beNil())
                     }
                     
+                    it("returns identical signals for inflight requests") {
+                        let target: GitHub = .Zen
+
+                        var response: MoyaResponse!
+
+                        let outerSignal = provider.request(target)
+                        outerSignal >- subscribeNext { (response) -> Void in
+                            expect(provider.inflightRequests.count).to(equal(1))
+
+                            let innerSignal = provider.request(target)
+                            innerSignal >- subscribeNext { (object) -> Void in
+                                expect(provider.inflightRequests.count).to(equal(1))
+                            }
+                        }
+
+                        expect(provider.inflightRequests.count).to(equal(0))
+                    }
                 })
                 
                 describe("a subsclassed reactive provider that tracks cancellation with delayed stubs") {

--- a/Demo/DemoTests/MoyaProviderSpec.swift
+++ b/Demo/DemoTests/MoyaProviderSpec.swift
@@ -10,6 +10,7 @@ import Quick
 import Moya
 import Nimble
 import ReactiveCocoa
+import RxSwift
 
 class MoyaProviderSpec: QuickSpec {
     override func spec() {
@@ -236,6 +237,50 @@ class MoyaProviderSpec: QuickSpec {
                         
                         expect(provider.inflightRequests.count).to(equal(0))
                     }
+                })
+                
+                describe("a RxSwift provider", { () -> () in
+                    var provider: RxMoyaProvider<GitHub>!
+                    
+                    beforeEach {
+                        provider = RxMoyaProvider(endpointsClosure: endpointsClosure, stubResponses: true)
+                    }
+                    
+                    it("returns a MoyaResponse object") {
+                        var called = false
+                        
+                        provider.request(.Zen) >- subscribeNext { (object) -> Void in
+                            called = true
+                        }
+                        
+                        expect(called).to(beTruthy())
+                    }
+                    
+                    it("returns stubbed data for zen request") {
+                        var message: String?
+                        
+                        let target: GitHub = .Zen
+                        provider.request(target) >- subscribeNext { (response) -> Void in
+                            message = NSString(data: response.data, encoding: NSUTF8StringEncoding) as? String
+                        }
+                        
+                        let sampleString = NSString(data: (target.sampleData as NSData), encoding: NSUTF8StringEncoding)
+                        expect(message).to(equal(sampleString))
+                    }
+
+                    it("returns correct data for user profile request") {
+                        var receivedResponse: NSDictionary?
+                        
+                        let target: GitHub = .UserProfile("ashfurrow")
+                        provider.request(target) >- subscribeNext { (response) -> Void in
+                            receivedResponse = NSJSONSerialization.JSONObjectWithData(response.data, options: nil, error: nil) as? NSDictionary
+                        }
+                        
+                        let sampleData = target.sampleData as NSData
+                        let sampleResponse: NSDictionary = NSJSONSerialization.JSONObjectWithData(sampleData, options: nil, error: nil) as! NSDictionary
+                        expect(receivedResponse).toNot(beNil())
+                    }
+                    
                 })
                 
                 describe("a subsclassed reactive provider that tracks cancellation with delayed stubs") {

--- a/Demo/Podfile
+++ b/Demo/Podfile
@@ -6,6 +6,7 @@ use_frameworks!
 
 pod 'ReactiveCocoa', '3.0-beta.6'
 pod 'Moya/Reactive', :path => "../"
+pod 'Moya/RxSwift', :path => "../"
 pod 'Moya', :path => "../"
 
 target 'DemoTests' do

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -6,8 +6,13 @@ PODS:
   - Moya/Core (1.0.0):
     - Alamofire (~> 1.2.0)
   - Moya/Reactive (1.0.0):
-    - Moya/Core
+    - Moya/ReactiveCore
     - ReactiveCocoa (= 3.0-beta.6)
+  - Moya/ReactiveCore (1.0.0):
+    - Moya/Core
+  - Moya/RxSwift (1.0.0):
+    - Moya/ReactiveCore
+    - RxSwift (= 1.4)
   - Nimble (0.4.2)
   - OHHTTPStubs (4.0.2)
   - Quick (0.3.1)
@@ -28,10 +33,12 @@ PODS:
     - Result (~> 0.4.1)
   - Result (0.4.3):
     - Box (~> 1.2)
+  - RxSwift (1.4)
 
 DEPENDENCIES:
   - Moya (from `../`)
   - Moya/Reactive (from `../`)
+  - Moya/RxSwift (from `../`)
   - Nimble
   - OHHTTPStubs
   - Quick
@@ -44,11 +51,12 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Alamofire: 11a6022f5089887d92ffb5a3014c97a0a915ab98
   Box: a92e8aa4c099e6bc0733829665caf9e668ef53b8
-  Moya: 8366901250530a71a8b7fc27c00e03693a7ed10d
+  Moya: 64756df795885a5c283a226e6cc2a7c74632c9da
   Nimble: 49b7a7da8919f42823d37c6d68cc6d15a7009f32
   OHHTTPStubs: dbd1957d414659783e07b49c961940b7564c23d9
   Quick: 824572d3d198d51e52cf4aa722cebf7e59952a35
   ReactiveCocoa: 859d1dd9dd38d6f2fa4a6917259bb2b512f3c5f7
   Result: 910839ce03c5c573ec94026678b7cecb69ee862e
+  RxSwift: db92214e17226bf61c3649180286c8c7baf3712b
 
-COCOAPODS: 0.37.1
+COCOAPODS: 0.37.2

--- a/Moya+ReactiveCocoa.swift
+++ b/Moya+ReactiveCocoa.swift
@@ -9,26 +9,6 @@
 import Foundation
 import ReactiveCocoa
 
-public class MoyaResponse: NSObject, Printable, DebugPrintable {
-    public let statusCode: Int
-    public let data: NSData
-    public let response: NSURLResponse?
-
-    public init(statusCode: Int, data: NSData, response: NSURLResponse?) {
-        self.statusCode = statusCode
-        self.data = data
-        self.response = response
-    }
-    
-    override public var description: String {
-        return "Status Code: \(statusCode), Data Length: \(data.length)"
-    }
-    
-    override public var debugDescription: String {
-        return description
-    }
-}
-
 /// Subclass of MoyaProvider that returns RACSignal instances when requests are made. Much better than using completion closures.
 public class ReactiveMoyaProvider<T where T: MoyaTarget>: MoyaProvider<T> {
     /// Current requests that have not completed or errored yet.

--- a/Moya+ReactiveCocoa.swift
+++ b/Moya+ReactiveCocoa.swift
@@ -69,15 +69,3 @@ public class ReactiveMoyaProvider<T where T: MoyaTarget>: MoyaProvider<T> {
         }
     }
 }
-
-/// Required for making Endpoint conform to Equatable.
-public func ==<T>(lhs: Endpoint<T>, rhs: Endpoint<T>) -> Bool {
-    return lhs.urlRequest.isEqual(rhs.urlRequest)
-}
-
-/// Required for using Endpoint as a key type in a Dictionary.
-extension Endpoint: Equatable, Hashable {
-    public var hashValue: Int {
-        return urlRequest.hash
-    }
-}

--- a/Moya+RxSwift.swift
+++ b/Moya+RxSwift.swift
@@ -11,6 +11,9 @@ import RxSwift
 
 /// Subclass of MoyaProvider that returns Observable instances when requests are made. Much better than using completion closures.
 public class RxMoyaProvider<T where T: MoyaTarget>: MoyaProvider<T> {
+    /// Current requests that have not completed or errored yet.
+    /// Note: Do not access this directly. It is public only for unit-testing purposes (sigh).
+    public var inflightRequests = Dictionary<Endpoint<T>, Observable<MoyaResponse>>()
 
     /// Initializes a reactive provider.
     override public init(endpointsClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping(), endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEnpointResolution(), stubResponses: Bool = false, stubBehavior: MoyaStubbedBehavior = MoyaProvider.DefaultStubBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil) {
@@ -21,25 +24,44 @@ public class RxMoyaProvider<T where T: MoyaTarget>: MoyaProvider<T> {
     public func request(token: T) -> Observable<MoyaResponse> {
         let endpoint = self.endpoint(token)
 
-        return AnonymousObservable { [weak self] observer in
-            let cancellableToken = self?.request(token) { (data, statusCode, response, error) -> () in
-                if let error = error {
-                    if let statusCode = statusCode {
-                        observer.on(.Error(NSError(domain: error.domain, code: statusCode, userInfo: error.userInfo)))
+        return defer {  [weak self] () -> Observable<MoyaResponse> in
+            if let existingObservable = self?.inflightRequests[endpoint] {
+                return existingObservable
+            }
+
+            let observable: Observable<MoyaResponse> =  AnonymousObservable { observer in
+                let cancellableToken = self?.request(token) { (data, statusCode, response, error) -> () in
+                    if let error = error {
+                        if let statusCode = statusCode {
+                            observer.on(.Error(NSError(domain: error.domain, code: statusCode, userInfo: error.userInfo)))
+                        } else {
+                            observer.on(.Error(error))
+                        }
                     } else {
-                        observer.on(.Error(error))
+                        if let data = data {
+                            observer.on(.Next(RxBox(MoyaResponse(statusCode: statusCode!, data: data, response: response))))
+                        }
+                        observer.on(.Completed)
                     }
-                } else {
-                    if let data = data {
-                        observer.on(.Next(RxBox(MoyaResponse(statusCode: statusCode!, data: data, response: response))))
+                }
+
+                return AnonymousDisposable {
+                    if let weakSelf = self {
+                        objc_sync_enter(weakSelf)
+                        weakSelf.inflightRequests[endpoint] = nil
+                        cancellableToken?.cancel()
+                        objc_sync_exit(weakSelf)
                     }
-                    observer.on(.Completed)
                 }
             }
             
-            return AnonymousDisposable {
-                cancellableToken?.cancel()
+            if let weakSelf = self {
+                objc_sync_enter(weakSelf)
+                weakSelf.inflightRequests[endpoint] = observable
+                objc_sync_exit(weakSelf)
             }
+
+            return observable
         }
     }
 }

--- a/Moya+RxSwift.swift
+++ b/Moya+RxSwift.swift
@@ -1,0 +1,45 @@
+//
+//  Moya+RxSwift.swift
+//  Moya
+//
+//  Created by Andre Carvalho on 2015-06-05
+//  Copyright (c) 2015 Ash Furrow. All rights reserved.
+//
+
+import Foundation
+import RxSwift
+
+/// Subclass of MoyaProvider that returns Observable instances when requests are made. Much better than using completion closures.
+public class RxMoyaProvider<T where T: MoyaTarget>: MoyaProvider<T> {
+
+    /// Initializes a reactive provider.
+    override public init(endpointsClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping(), endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEnpointResolution(), stubResponses: Bool = false, stubBehavior: MoyaStubbedBehavior = MoyaProvider.DefaultStubBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil) {
+        super.init(endpointsClosure: endpointsClosure, endpointResolver: endpointResolver, stubResponses: stubResponses, networkActivityClosure: networkActivityClosure)
+    }
+
+    /// Designated request-making method.
+    public func request(token: T) -> Observable<MoyaResponse> {
+        let endpoint = self.endpoint(token)
+
+        return AnonymousObservable { [weak self] observer in
+            let cancellableToken = self?.request(token) { (data, statusCode, response, error) -> () in
+                if let error = error {
+                    if let statusCode = statusCode {
+                        observer.on(.Error(NSError(domain: error.domain, code: statusCode, userInfo: error.userInfo)))
+                    } else {
+                        observer.on(.Error(error))
+                    }
+                } else {
+                    if let data = data {
+                        observer.on(.Next(RxBox(MoyaResponse(statusCode: statusCode!, data: data, response: response))))
+                    }
+                    observer.on(.Completed)
+                }
+            }
+            
+            return AnonymousDisposable {
+                cancellableToken?.cancel()
+            }
+        }
+    }
+}

--- a/Moya.podspec
+++ b/Moya.podspec
@@ -3,8 +3,8 @@ Pod::Spec.new do |s|
   s.version      = "1.0.0"
   s.summary      = "Network abstraction layer written in Swift"
   s.description  = <<-EOS
-  Moya abstracts network commands using Swift Generics to provide developers 
-  with more compile-time confidence. 
+  Moya abstracts network commands using Swift Generics to provide developers
+  with more compile-time confidence.
 
   A ReactiveCocoa extension exists as well. Instructions for its installation
   are in [the README](https://github.com/ashfurrow/Moya).
@@ -24,9 +24,20 @@ Pod::Spec.new do |s|
     ss.framework  = "Foundation"
   end
 
+  s.subspec "ReactiveCore" do |ss|
+    ss.source_files = "MoyaResponse.swift"
+    ss.dependency "Moya/Core"
+  end
+
   s.subspec "Reactive" do |ss|
     ss.source_files = "Moya+ReactiveCocoa.swift", "RACSignal+Moya.swift"
-    ss.dependency "Moya/Core"
+    ss.dependency "Moya/ReactiveCore"
     ss.dependency "ReactiveCocoa", "3.0-beta.6"
+  end
+
+  s.subspec "RxSwift" do |ss|
+    ss.source_files = "Moya+RxSwift.swift"
+    ss.dependency "Moya/ReactiveCore"
+    ss.dependency "RxSwift", "1.4"
   end
 end

--- a/MoyaResponse.swift
+++ b/MoyaResponse.swift
@@ -1,0 +1,30 @@
+//
+//  File.swift
+//  Pods
+//
+//  Created by Andre Carvalho on 06/06/15.
+//
+//
+
+import Foundation
+
+public class MoyaResponse: NSObject, Printable, DebugPrintable {
+    public let statusCode: Int
+    public let data: NSData
+    public let response: NSURLResponse?
+    
+    public init(statusCode: Int, data: NSData, response: NSURLResponse?) {
+        self.statusCode = statusCode
+        self.data = data
+        self.response = response
+    }
+    
+    override public var description: String {
+        return "Status Code: \(statusCode), Data Length: \(data.length)"
+    }
+    
+    override public var debugDescription: String {
+        return description
+    }
+}
+

--- a/MoyaResponse.swift
+++ b/MoyaResponse.swift
@@ -1,9 +1,9 @@
 //
-//  File.swift
-//  Pods
+//  MoyaResponse.swift
+//  Moya
 //
-//  Created by Andre Carvalho on 06/06/15.
-//
+//  Created by Andre Carvalho on 2015-06-06
+//  Copyright (c) 2015 Ash Furrow. All rights reserved.
 //
 
 import Foundation
@@ -25,6 +25,18 @@ public class MoyaResponse: NSObject, Printable, DebugPrintable {
     
     override public var debugDescription: String {
         return description
+    }
+}
+
+/// Required for making Endpoint conform to Equatable.
+public func ==<T>(lhs: Endpoint<T>, rhs: Endpoint<T>) -> Bool {
+    return lhs.urlRequest.isEqual(rhs.urlRequest)
+}
+
+/// Required for using Endpoint as a key type in a Dictionary.
+extension Endpoint: Equatable, Hashable {
+    public var hashValue: Int {
+        return urlRequest.hash
     }
 }
 


### PR DESCRIPTION
This is my initial attempt to add RxSwift support, as mentioned in #124 

Still missing the `inflightRequests` management like in the RAC provider. And the filters as well. I had to factor out the MoyaResponse so it can be a common core for the two reactive frameworks.

Feedback is very much appreciated! :smiley: 

Fixes #124.