### PR TITLE
New Stubbing arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - **Breaking change** Renames `Moya/Reacitve` subspec to `Moya/ReactiveCocoa`.
 - **Breaking change** Removes `stubResponses` from initializer; replaced with new stubbing behavior `.NoStubbing`. Added class methods to `MoyaProvider` to provide defaults, while allowing users to still change stubbing behaviour on a per-request basis.
 - **Breaking change** Redefines types of `DefaultEndpointMapping` and `DefaultEnpointResolution` class functions on `MoyaProvider`. You no longer invoke these functions to return a closure, rather, you reference the functions themselves _as_ closures. 
+- **Breaking change** Renames `endpointsClosure` parameter and property of `MoyaProvider` to `endpointClosure`.
 - Fixes problem that the `ReactiveMoyaProvider` initializer would not respect the stubbing behaviour it was passed. 
 
 # 1.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 - **Breaking change** Combines `MoyaPath` and `MoyaTarget` protocols.
 - **Breaking change** Renames `Moya/Reacitve` subspec to `Moya/ReactiveCocoa`.
 - **Breaking change** Removes `stubResponses` from initializer; replaced with new stubbing behavior `.NoStubbing`. Added class methods to `MoyaProvider` to provide defaults, while allowing users to still change stubbing behaviour on a per-request basis.
-- Fixes problem that the `ReactiveMoyaProvider` initializer would not respect the stubbing behaviour it was passed.
+- **Breaking change** Redefines types of `DefaultEndpointMapping` and `DefaultEnpointResolution` class functions on `MoyaProvider`. You no longer invoke these functions to return a closure, rather, you reference the functions themselves _as_ closures. 
+- Fixes problem that the `ReactiveMoyaProvider` initializer would not respect the stubbing behaviour it was passed. 
 
 # 1.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - **Breaking change** Combines `MoyaPath` and `MoyaTarget` protocols.
 - **Breaking change** Renames `Moya/Reacitve` subspec to `Moya/ReactiveCocoa`.
+- **Breaking change** Removes `stubResponses` from initializer; replaced with new stubbing behavior `.NoStubbing`. Added class methods to `MoyaProvider` to provide defaults, while allowing users to still change stubbing behaviour on a per-request basis.
+- Fixes problem that the `ReactiveMoyaProvider` initializer would not respect the stubbing behaviour it was passed.
 
 # 1.1.1
 

--- a/Demo/DemoTests/MoyaProviderIntegrationTests.swift
+++ b/Demo/DemoTests/MoyaProviderIntegrationTests.swift
@@ -35,7 +35,7 @@ class MoyaProviderIntegrationTests: QuickSpec {
                 describe("a provider") { () -> () in
                     var provider: MoyaProvider<GitHub>!
                     beforeEach {
-                        provider = MoyaProvider(endpointsClosure: endpointsClosure)
+                        provider = MoyaProvider()
                         return
                     }
                     
@@ -81,7 +81,7 @@ class MoyaProviderIntegrationTests: QuickSpec {
                 describe("a provider with network activity closures") {
                     it("notifies at the beginning of network requests") {
                         var called = false
-                        var provider = MoyaProvider(endpointsClosure: endpointsClosure, networkActivityClosure: { (change) -> () in
+                        var provider = MoyaProvider<GitHub>(networkActivityClosure: { (change) -> () in
                             if change == .Began {
                                 called = true
                             }
@@ -95,7 +95,7 @@ class MoyaProviderIntegrationTests: QuickSpec {
 
                     it("notifies at the end of network requests") {
                         var called = false
-                        var provider = MoyaProvider(endpointsClosure: endpointsClosure, networkActivityClosure: { (change) -> () in
+                        var provider = MoyaProvider<GitHub>(networkActivityClosure: { (change) -> () in
                             if change == .Ended {
                                 called = true
                             }
@@ -111,7 +111,7 @@ class MoyaProviderIntegrationTests: QuickSpec {
                 describe("a reactive provider") { () -> () in
                     var provider: ReactiveMoyaProvider<GitHub>!
                     beforeEach {
-                        provider = ReactiveMoyaProvider(endpointsClosure: endpointsClosure)
+                        provider = ReactiveMoyaProvider()
                     }
                     
                     it("returns some data for zen request") {

--- a/Demo/DemoTests/MoyaProviderIntegrationTests.swift
+++ b/Demo/DemoTests/MoyaProviderIntegrationTests.swift
@@ -35,7 +35,7 @@ class MoyaProviderIntegrationTests: QuickSpec {
                 describe("a provider") { () -> () in
                     var provider: MoyaProvider<GitHub>!
                     beforeEach {
-                        provider = MoyaProvider()
+                        provider = MoyaProvider<GitHub>()
                         return
                     }
                     
@@ -111,7 +111,7 @@ class MoyaProviderIntegrationTests: QuickSpec {
                 describe("a reactive provider") { () -> () in
                     var provider: ReactiveMoyaProvider<GitHub>!
                     beforeEach {
-                        provider = ReactiveMoyaProvider()
+                        provider = ReactiveMoyaProvider<GitHub>()
                     }
                     
                     it("returns some data for zen request") {

--- a/Demo/DemoTests/MoyaProviderSpec.swift
+++ b/Demo/DemoTests/MoyaProviderSpec.swift
@@ -110,11 +110,7 @@ class MoyaProviderSpec: QuickSpec {
                 })
 
                 it("delays execution when appropriate") {
-                    let closure = { (target: GitHub) -> (Moya.StubbedBehavior) in
-                        return .Delayed(seconds: 2)
-                    }
-
-                    let provider = MoyaProvider(stubBehavior: closure)
+                    let provider = MoyaProvider<GitHub>(stubBehavior: MoyaProvider<GitHub>.DelayedStubbingBehaviour(2))
 
                     let startDate = NSDate()
                     var endDate: NSDate?
@@ -314,11 +310,8 @@ class MoyaProviderSpec: QuickSpec {
                     var provider: ReactiveMoyaProvider<GitHub>!
                     beforeEach {
                         TestCancellable.cancelled = false
-                        let closure = { (target: GitHub) -> (Moya.StubbedBehavior) in
-                            return .Delayed(seconds: 1)
-                        }
                         
-                        provider = TestProvider<GitHub>(stubBehavior: closure)
+                        provider = TestProvider<GitHub>(stubBehavior: MoyaProvider<GitHub>.DelayedStubbingBehaviour(1))
                     }
                     
                     it("cancels network request when subscription is cancelled") {

--- a/Demo/DemoTests/MoyaProviderSpec.swift
+++ b/Demo/DemoTests/MoyaProviderSpec.swift
@@ -11,7 +11,7 @@ class MoyaProviderSpec: QuickSpec {
                 describe("a provider", {
                     var provider: MoyaProvider<GitHub>!
                     beforeEach {
-                        provider = MoyaProvider(endpointsClosure: endpointsClosure, stubResponses: true)
+                        provider = MoyaProvider<GitHub>(stubBehavior: MoyaProvider.ImmediateStubbingBehaviour)
                     }
                     
                     it("returns stubbed data for zen request") {
@@ -62,7 +62,7 @@ class MoyaProviderSpec: QuickSpec {
 
                 it("notifies at the beginning of network requests") {
                     var called = false
-                    var provider = MoyaProvider(endpointsClosure: endpointsClosure, stubResponses: true, networkActivityClosure: { (change) -> () in
+                    var provider = MoyaProvider<GitHub>(stubBehavior: MoyaProvider.ImmediateStubbingBehaviour, networkActivityClosure: { (change) -> () in
                         if change == .Began {
                             called = true
                         }
@@ -76,7 +76,7 @@ class MoyaProviderSpec: QuickSpec {
 
                 it("notifies at the end of network requests") {
                     var called = false
-                    var provider = MoyaProvider(endpointsClosure: endpointsClosure, stubResponses: true, networkActivityClosure: { (change) -> () in
+                    var provider = MoyaProvider<GitHub>(stubBehavior: MoyaProvider.ImmediateStubbingBehaviour, networkActivityClosure: { (change) -> () in
                         if change == .Ended {
                             called = true
                         }
@@ -91,7 +91,7 @@ class MoyaProviderSpec: QuickSpec {
                 describe("a provider with lazy data", { () -> () in
                     var provider: MoyaProvider<GitHub>!
                     beforeEach {
-                        provider = MoyaProvider(endpointsClosure: lazyEndpointsClosure, stubResponses: true)
+                        provider = MoyaProvider<GitHub>(endpointsClosure: lazyEndpointsClosure, stubBehavior: MoyaProvider.ImmediateStubbingBehaviour)
                     }
 
                     it("returns stubbed data for zen request") {
@@ -114,7 +114,7 @@ class MoyaProviderSpec: QuickSpec {
                         return .Delayed(seconds: 2)
                     }
 
-                    let provider = MoyaProvider(endpointsClosure: endpointsClosure, stubResponses: true, stubBehavior: closure)
+                    let provider = MoyaProvider(stubBehavior: closure)
 
                     let startDate = NSDate()
                     var endDate: NSDate?
@@ -143,7 +143,7 @@ class MoyaProviderSpec: QuickSpec {
                             executed = true
                             return endpoint.urlRequest
                         }
-                        provider = MoyaProvider(endpointsClosure: endpointsClosure, endpointResolver: endpointResolution, stubResponses: true)
+                        provider = MoyaProvider<GitHub>(endpointResolver: endpointResolution, stubBehavior: MoyaProvider.ImmediateStubbingBehaviour)
                     }
                     
                     it("executes the endpoint resolver") {
@@ -158,7 +158,7 @@ class MoyaProviderSpec: QuickSpec {
                 describe("a reactive provider", { () -> () in
                     var provider: ReactiveMoyaProvider<GitHub>!
                     beforeEach {
-                        provider = ReactiveMoyaProvider(endpointsClosure: endpointsClosure, stubResponses: true)
+                        provider = ReactiveMoyaProvider<GitHub>(stubBehavior: MoyaProvider.ImmediateStubbingBehaviour)
                     }
                     
                     it("returns a MoyaResponse object") {
@@ -235,7 +235,7 @@ class MoyaProviderSpec: QuickSpec {
                     var provider: RxMoyaProvider<GitHub>!
                     
                     beforeEach {
-                        provider = RxMoyaProvider(endpointsClosure: endpointsClosure, stubResponses: true)
+                        provider = RxMoyaProvider(stubBehavior: MoyaProvider.ImmediateStubbingBehaviour)
                     }
                     
                     it("returns a MoyaResponse object") {
@@ -302,8 +302,8 @@ class MoyaProviderSpec: QuickSpec {
                     }
 
                     class TestProvider<T: MoyaTarget>: ReactiveMoyaProvider<T> {
-                        override init(endpointsClosure: MoyaEndpointsClosure, endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEnpointResolution(), stubResponses: Bool = false, stubBehavior: MoyaStubbedBehavior = MoyaProvider.DefaultStubBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil) {
-                            super.init(endpointsClosure: endpointsClosure, endpointResolver: endpointResolver, stubResponses: stubResponses, networkActivityClosure: networkActivityClosure)
+                        override init(endpointsClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping(), endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEnpointResolution(), stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil) {
+                            super.init(endpointsClosure: endpointsClosure, endpointResolver: endpointResolver, stubBehavior: stubBehavior, networkActivityClosure: networkActivityClosure)
                         }
 
                         override func request(token: T, completion: MoyaCompletion) -> Cancellable {
@@ -318,7 +318,7 @@ class MoyaProviderSpec: QuickSpec {
                             return .Delayed(seconds: 1)
                         }
                         
-                        provider = TestProvider(endpointsClosure: endpointsClosure, stubResponses: true, stubBehavior: closure)
+                        provider = TestProvider<GitHub>(stubBehavior: closure)
                     }
                     
                     it("cancels network request when subscription is cancelled") {
@@ -340,7 +340,7 @@ class MoyaProviderSpec: QuickSpec {
                 describe("a provider") { () -> () in
                     var provider: MoyaProvider<GitHub>!
                     beforeEach {
-                        provider = MoyaProvider(endpointsClosure: failureEndpointsClosure, stubResponses: true)
+                        provider = MoyaProvider(endpointsClosure: failureEndpointsClosure, stubBehavior: MoyaProvider.ImmediateStubbingBehaviour)
                     }
                     
                     it("returns stubbed data for zen request") {
@@ -388,7 +388,7 @@ class MoyaProviderSpec: QuickSpec {
                 describe("a reactive provider", { () -> () in
                     var provider: ReactiveMoyaProvider<GitHub>!
                     beforeEach {
-                        provider = ReactiveMoyaProvider(endpointsClosure: failureEndpointsClosure, stubResponses: true)
+                        provider = ReactiveMoyaProvider<GitHub>(endpointsClosure: failureEndpointsClosure, stubBehavior: MoyaProvider.ImmediateStubbingBehaviour)
                     }
                     
                     it("returns stubbed data for zen request") {
@@ -417,7 +417,7 @@ class MoyaProviderSpec: QuickSpec {
                 describe("a failing reactive provider") {
                     var provider: ReactiveMoyaProvider<GitHub>!
                     beforeEach {
-                        provider = ReactiveMoyaProvider(endpointsClosure: failureEndpointsClosure, stubResponses: true)
+                        provider = ReactiveMoyaProvider<GitHub>(endpointsClosure: failureEndpointsClosure, stubBehavior: MoyaProvider.ImmediateStubbingBehaviour)
                     }
 
                     it("returns the HTTP status code as the error code") {

--- a/Demo/DemoTests/MoyaProviderSpec.swift
+++ b/Demo/DemoTests/MoyaProviderSpec.swift
@@ -298,7 +298,7 @@ class MoyaProviderSpec: QuickSpec {
                     }
 
                     class TestProvider<T: MoyaTarget>: ReactiveMoyaProvider<T> {
-                        override init(endpointsClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping(), endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEnpointResolution(), stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil) {
+                        override init(endpointsClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping, endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEnpointResolution, stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil) {
                             super.init(endpointsClosure: endpointsClosure, endpointResolver: endpointResolver, stubBehavior: stubBehavior, networkActivityClosure: networkActivityClosure)
                         }
 

--- a/Demo/DemoTests/MoyaProviderSpec.swift
+++ b/Demo/DemoTests/MoyaProviderSpec.swift
@@ -110,7 +110,7 @@ class MoyaProviderSpec: QuickSpec {
                 })
 
                 it("delays execution when appropriate") {
-                    let provider = MoyaProvider<GitHub>(stubBehavior: MoyaProvider<GitHub>.DelayedStubbingBehaviour(2))
+                    let provider = MoyaProvider<GitHub>(stubBehavior: MoyaProvider.DelayedStubbingBehaviour(2))
 
                     let startDate = NSDate()
                     var endDate: NSDate?
@@ -311,7 +311,7 @@ class MoyaProviderSpec: QuickSpec {
                     beforeEach {
                         TestCancellable.cancelled = false
                         
-                        provider = TestProvider<GitHub>(stubBehavior: MoyaProvider<GitHub>.DelayedStubbingBehaviour(1))
+                        provider = TestProvider<GitHub>(stubBehavior: MoyaProvider.DelayedStubbingBehaviour(1))
                     }
                     
                     it("cancels network request when subscription is cancelled") {

--- a/Demo/DemoTests/MoyaProviderSpec.swift
+++ b/Demo/DemoTests/MoyaProviderSpec.swift
@@ -91,7 +91,7 @@ class MoyaProviderSpec: QuickSpec {
                 describe("a provider with lazy data", { () -> () in
                     var provider: MoyaProvider<GitHub>!
                     beforeEach {
-                        provider = MoyaProvider<GitHub>(endpointsClosure: lazyEndpointsClosure, stubBehavior: MoyaProvider.ImmediateStubbingBehaviour)
+                        provider = MoyaProvider<GitHub>(endpointClosure: lazyEndpointClosure, stubBehavior: MoyaProvider.ImmediateStubbingBehaviour)
                     }
 
                     it("returns stubbed data for zen request") {
@@ -298,8 +298,8 @@ class MoyaProviderSpec: QuickSpec {
                     }
 
                     class TestProvider<T: MoyaTarget>: ReactiveMoyaProvider<T> {
-                        override init(endpointsClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping, endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEnpointResolution, stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil) {
-                            super.init(endpointsClosure: endpointsClosure, endpointResolver: endpointResolver, stubBehavior: stubBehavior, networkActivityClosure: networkActivityClosure)
+                        override init(endpointClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping, endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEnpointResolution, stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil) {
+                            super.init(endpointClosure: endpointClosure, endpointResolver: endpointResolver, stubBehavior: stubBehavior, networkActivityClosure: networkActivityClosure)
                         }
 
                         override func request(token: T, completion: MoyaCompletion) -> Cancellable {
@@ -333,7 +333,7 @@ class MoyaProviderSpec: QuickSpec {
                 describe("a provider") { () -> () in
                     var provider: MoyaProvider<GitHub>!
                     beforeEach {
-                        provider = MoyaProvider(endpointsClosure: failureEndpointsClosure, stubBehavior: MoyaProvider.ImmediateStubbingBehaviour)
+                        provider = MoyaProvider(endpointClosure: failureEndpointClosure, stubBehavior: MoyaProvider.ImmediateStubbingBehaviour)
                     }
                     
                     it("returns stubbed data for zen request") {
@@ -381,7 +381,7 @@ class MoyaProviderSpec: QuickSpec {
                 describe("a reactive provider", { () -> () in
                     var provider: ReactiveMoyaProvider<GitHub>!
                     beforeEach {
-                        provider = ReactiveMoyaProvider<GitHub>(endpointsClosure: failureEndpointsClosure, stubBehavior: MoyaProvider.ImmediateStubbingBehaviour)
+                        provider = ReactiveMoyaProvider<GitHub>(endpointClosure: failureEndpointClosure, stubBehavior: MoyaProvider.ImmediateStubbingBehaviour)
                     }
                     
                     it("returns stubbed data for zen request") {
@@ -410,7 +410,7 @@ class MoyaProviderSpec: QuickSpec {
                 describe("a failing reactive provider") {
                     var provider: ReactiveMoyaProvider<GitHub>!
                     beforeEach {
-                        provider = ReactiveMoyaProvider<GitHub>(endpointsClosure: failureEndpointsClosure, stubBehavior: MoyaProvider.ImmediateStubbingBehaviour)
+                        provider = ReactiveMoyaProvider<GitHub>(endpointClosure: failureEndpointClosure, stubBehavior: MoyaProvider.ImmediateStubbingBehaviour)
                     }
 
                     it("returns the HTTP status code as the error code") {

--- a/Demo/DemoTests/TestResources.swift
+++ b/Demo/DemoTests/TestResources.swift
@@ -43,11 +43,11 @@ public func url(route: MoyaTarget) -> String {
     return route.baseURL.URLByAppendingPathComponent(route.path).absoluteString!
 }
 
-let lazyEndpointsClosure = { (target: GitHub) -> Endpoint<GitHub> in
+let lazyEndpointClosure = { (target: GitHub) -> Endpoint<GitHub> in
     return Endpoint<GitHub>(URL: url(target), sampleResponse: .Closure({.Success(200, {target.sampleData})}), method: target.method, parameters: target.parameters)
 }
 
-let failureEndpointsClosure = { (target: GitHub) -> Endpoint<GitHub> in
+let failureEndpointClosure = { (target: GitHub) -> Endpoint<GitHub> in
     let errorData = "Houston, we have a problem".dataUsingEncoding(NSUTF8StringEncoding)!
     return Endpoint<GitHub>(URL: url(target), sampleResponse: .Error(401, NSError(domain: "com.moya.error", code: 0, userInfo: nil), {errorData}), method: target.method, parameters: target.parameters)
 }

--- a/Demo/DemoTests/TestResources.swift
+++ b/Demo/DemoTests/TestResources.swift
@@ -43,10 +43,6 @@ public func url(route: MoyaTarget) -> String {
     return route.baseURL.URLByAppendingPathComponent(route.path).absoluteString!
 }
 
-let endpointsClosure = { (target: GitHub) -> Endpoint<GitHub> in
-    return Endpoint<GitHub>(URL: url(target), sampleResponse: .Success(200, {target.sampleData}), method: target.method, parameters: target.parameters)
-}
-
 let lazyEndpointsClosure = { (target: GitHub) -> Endpoint<GitHub> in
     return Endpoint<GitHub>(URL: url(target), sampleResponse: .Closure({.Success(200, {target.sampleData})}), method: target.method, parameters: target.parameters)
 }

--- a/Moya/Moya.swift
+++ b/Moya/Moya.swift
@@ -155,8 +155,8 @@ public class MoyaProvider<T: MoyaTarget> {
         return .Immediate
     }
 
-    public class func DelayedStubbingBehaviour(seconds: NSTimeInterval)(_: T) -> Moya.StubbedBehavior {
-        return .Delayed(seconds: seconds)
+    public class func DelayedStubbingBehaviour(seconds: NSTimeInterval) -> MoyaStubbedBehavior {
+        return { (_: T) -> Moya.StubbedBehavior in return .Delayed(seconds: seconds) }
     }
 }
 

--- a/Moya/Moya.swift
+++ b/Moya/Moya.swift
@@ -65,6 +65,7 @@ public class Moya {
     }
 
     public enum StubbedBehavior {
+        case NoStubbing
         case Immediate
         case Delayed(seconds: NSTimeInterval)
     }
@@ -103,15 +104,13 @@ public class MoyaProvider<T: MoyaTarget> {
     
     public let endpointsClosure: MoyaEndpointsClosure
     public let endpointResolver: MoyaEndpointResolution
-    public let stubResponses: Bool
     public let stubBehavior: MoyaStubbedBehavior
     public let networkActivityClosure: Moya.NetworkActivityClosure?
     
     /// Initializes a provider.
-    public init(endpointsClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping(), endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEnpointResolution(), stubResponses: Bool = false, stubBehavior: MoyaStubbedBehavior = MoyaProvider.DefaultStubBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil) {
+    public init(endpointsClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping(), endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEnpointResolution(), stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil) {
         self.endpointsClosure = endpointsClosure
         self.endpointResolver = endpointResolver
-        self.stubResponses = stubResponses
         self.stubBehavior = stubBehavior
         self.networkActivityClosure = networkActivityClosure
     }
@@ -125,67 +124,13 @@ public class MoyaProvider<T: MoyaTarget> {
     public func request(token: T, completion: MoyaCompletion) -> Cancellable {
         let endpoint = self.endpoint(token)
         let request = endpointResolver(endpoint: endpoint)
+        let stubBehavior = self.stubBehavior(token)
 
-        networkActivityClosure?(change: .Began)
-
-        if stubResponses {
-            
-            var canceled = false
-            let cancellableToken = CancellableToken { canceled = true }
-            
-            let behavior = stubBehavior(token)
-
-            let stub: () -> () = {
-                self.networkActivityClosure?(change: .Ended)
-                
-                if (canceled) {
-                    completion(data: nil, statusCode: nil, response: nil, error: NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled, userInfo: nil))
-                    return
-                }
-                
-                switch endpoint.sampleResponse.evaluate() {
-                    case .Success(let statusCode, let data):
-                        completion(data: data(), statusCode: statusCode, response:nil, error: nil)
-                    case .Error(let statusCode, let error, let data):
-                        completion(data: data?(), statusCode: statusCode, response:nil, error: error)
-                    case .Closure:
-                        break  // the `evaluate()` method will never actually return a .Closure
-                }
-            }
-
-            switch behavior {
-            case .Immediate:
-                stub()
-            case .Delayed(let delay):
-                let killTimeOffset = Int64(CDouble(delay) * CDouble(NSEC_PER_SEC))
-                let killTime = dispatch_time(DISPATCH_TIME_NOW, killTimeOffset)
-                dispatch_after(killTime, dispatch_get_main_queue()) {
-                    stub()
-                }
-            }
-            
-            return cancellableToken
-
-        } else {
-            // We need to keep a reference to the closure without a reference to ourself.
-            let networkActivityCallback = networkActivityClosure
-            let request = Alamofire.Manager.sharedInstance.request(request)
-                .response { (request: NSURLRequest, response: NSHTTPURLResponse?, data: AnyObject?, error: NSError?) -> () in
-                    networkActivityCallback?(change: .Ended)
-
-                    // Alamofire always sends the data param as an NSData? type, but we'll
-                    // add a check just in case something changes in the future.
-                    let statusCode = response?.statusCode
-                    if let data = data as? NSData {
-                        completion(data: data, statusCode: statusCode, response:response, error: error)
-                    } else {
-                        completion(data: nil, statusCode: statusCode, response:response, error: error)
-                    }
-            }
-            
-            return CancellableToken {
-                request.cancel()
-            }
+        switch stubBehavior {
+        case .NoStubbing:
+            return sendRequest(request, completion: completion)
+        default:
+            return stubRequest(request, completion: completion, endpoint: endpoint, stubBehavior: stubBehavior)
         }
     }
 
@@ -202,8 +147,83 @@ public class MoyaProvider<T: MoyaTarget> {
         }
     }
 
-    public class func DefaultStubBehavior(_: T) -> Moya.StubbedBehavior {
+    public class func NoStubbingBehavior(_: T) -> Moya.StubbedBehavior {
+        return .NoStubbing
+    }
+
+    public class func ImmediateStubbingBehaviour(_: T) -> Moya.StubbedBehavior {
         return .Immediate
+    }
+
+    public class func DelayedStubbingBehaviour(seconds: NSTimeInterval)(_: T) -> Moya.StubbedBehavior {
+        return .Delayed(seconds: seconds)
     }
 }
 
+private extension MoyaProvider {
+    func sendRequest(request: NSURLRequest, completion: MoyaCompletion) -> CancellableToken {
+
+        networkActivityClosure?(change: .Began)
+
+        // We need to keep a reference to the closure without a reference to ourself.
+        let networkActivityCallback = networkActivityClosure
+        let request = Alamofire.Manager.sharedInstance.request(request)
+            .response { (request: NSURLRequest, response: NSHTTPURLResponse?, data: AnyObject?, error: NSError?) -> () in
+                networkActivityCallback?(change: .Ended)
+
+                // Alamofire always sends the data param as an NSData? type, but we'll
+                // add a check just in case something changes in the future.
+                let statusCode = response?.statusCode
+                if let data = data as? NSData {
+                    completion(data: data, statusCode: statusCode, response:response, error: error)
+                } else {
+                    completion(data: nil, statusCode: statusCode, response:response, error: error)
+                }
+        }
+
+        return CancellableToken {
+            request.cancel()
+        }
+    }
+
+    func stubRequest(request: NSURLRequest, completion: MoyaCompletion, endpoint: Endpoint<T>, stubBehavior: Moya.StubbedBehavior) -> CancellableToken {
+        var canceled = false
+        let cancellableToken = CancellableToken { canceled = true }
+
+        // Begin network activity closure
+        networkActivityClosure?(change: .Began)
+
+        let stub: () -> () = {
+            self.networkActivityClosure?(change: .Ended)
+
+            if (canceled) {
+                completion(data: nil, statusCode: nil, response: nil, error: NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled, userInfo: nil))
+                return
+            }
+
+            switch endpoint.sampleResponse.evaluate() {
+            case .Success(let statusCode, let data):
+                completion(data: data(), statusCode: statusCode, response:nil, error: nil)
+            case .Error(let statusCode, let error, let data):
+                completion(data: data?(), statusCode: statusCode, response:nil, error: error)
+            case .Closure:
+                break  // the `evaluate()` method will never actually return a .Closure
+            }
+        }
+
+        switch stubBehavior {
+        case .Immediate:
+            stub()
+        case .Delayed(let delay):
+            let killTimeOffset = Int64(CDouble(delay) * CDouble(NSEC_PER_SEC))
+            let killTime = dispatch_time(DISPATCH_TIME_NOW, killTimeOffset)
+            dispatch_after(killTime, dispatch_get_main_queue()) {
+                stub()
+            }
+        case .NoStubbing:
+            fatalError("Method called to stub request when stubbing is disabled.")
+        }
+
+        return cancellableToken
+    }
+}

--- a/Moya/Moya.swift
+++ b/Moya/Moya.swift
@@ -102,14 +102,14 @@ public class MoyaProvider<T: MoyaTarget> {
     public typealias MoyaEndpointResolution = (endpoint: Endpoint<T>) -> (NSURLRequest)
     public typealias MoyaStubbedBehavior = ((T) -> (Moya.StubbedBehavior))
     
-    public let endpointsClosure: MoyaEndpointsClosure
+    public let endpointClosure: MoyaEndpointsClosure
     public let endpointResolver: MoyaEndpointResolution
     public let stubBehavior: MoyaStubbedBehavior
     public let networkActivityClosure: Moya.NetworkActivityClosure?
     
     /// Initializes a provider.
-    public init(endpointsClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping, endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEnpointResolution, stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil) {
-        self.endpointsClosure = endpointsClosure
+    public init(endpointClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping, endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEnpointResolution, stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil) {
+        self.endpointClosure = endpointClosure
         self.endpointResolver = endpointResolver
         self.stubBehavior = stubBehavior
         self.networkActivityClosure = networkActivityClosure
@@ -117,7 +117,7 @@ public class MoyaProvider<T: MoyaTarget> {
     
     /// Returns an Endpoint based on the token, method, and parameters by invoking the endpointsClosure.
     public func endpoint(token: T) -> Endpoint<T> {
-        return endpointsClosure(token)
+        return endpointClosure(token)
     }
     
     /// Designated request-making method.

--- a/Moya/Moya.swift
+++ b/Moya/Moya.swift
@@ -108,7 +108,7 @@ public class MoyaProvider<T: MoyaTarget> {
     public let networkActivityClosure: Moya.NetworkActivityClosure?
     
     /// Initializes a provider.
-    public init(endpointsClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping(), endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEnpointResolution(), stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil) {
+    public init(endpointsClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping, endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEnpointResolution, stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil) {
         self.endpointsClosure = endpointsClosure
         self.endpointResolver = endpointResolver
         self.stubBehavior = stubBehavior
@@ -134,17 +134,13 @@ public class MoyaProvider<T: MoyaTarget> {
         }
     }
 
-    public class func DefaultEndpointMapping() -> MoyaEndpointsClosure {
-        return { (target: T) -> Endpoint<T> in
-            let url = target.baseURL.URLByAppendingPathComponent(target.path).absoluteString
-            return Endpoint(URL: url!, sampleResponse: .Success(200, {target.sampleData}), method: target.method, parameters: target.parameters)
-        }
+    public class func DefaultEndpointMapping(target: T) -> Endpoint<T> {
+        let url = target.baseURL.URLByAppendingPathComponent(target.path).absoluteString
+        return Endpoint(URL: url!, sampleResponse: .Success(200, {target.sampleData}), method: target.method, parameters: target.parameters)
     }
 
-    public class func DefaultEnpointResolution() -> MoyaEndpointResolution {
-        return { (endpoint: Endpoint<T>) -> (NSURLRequest) in
-            return endpoint.urlRequest
-        }
+    public class func DefaultEnpointResolution(endpoint: Endpoint<T>) -> NSURLRequest {
+        return endpoint.urlRequest
     }
 
     public class func NoStubbingBehavior(_: T) -> Moya.StubbedBehavior {

--- a/Moya/ReactiveCocoa/Moya+ReactiveCocoa.swift
+++ b/Moya/ReactiveCocoa/Moya+ReactiveCocoa.swift
@@ -9,7 +9,7 @@ public class ReactiveMoyaProvider<T where T: MoyaTarget>: MoyaProvider<T> {
 
     /// Initializes a reactive provider.
     override public init(endpointsClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping(), endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEnpointResolution(), stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil) {
-        super.init(endpointsClosure: endpointsClosure, endpointResolver: endpointResolver, networkActivityClosure: networkActivityClosure)
+        super.init(endpointsClosure: endpointsClosure, endpointResolver: endpointResolver, stubBehavior: stubBehavior, networkActivityClosure: networkActivityClosure)
     }
 
     /// Designated request-making method.

--- a/Moya/ReactiveCocoa/Moya+ReactiveCocoa.swift
+++ b/Moya/ReactiveCocoa/Moya+ReactiveCocoa.swift
@@ -8,8 +8,8 @@ public class ReactiveMoyaProvider<T where T: MoyaTarget>: MoyaProvider<T> {
     public var inflightRequests = Dictionary<Endpoint<T>, RACSignal>()
 
     /// Initializes a reactive provider.
-    override public init(endpointsClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping, endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEnpointResolution, stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil) {
-        super.init(endpointsClosure: endpointsClosure, endpointResolver: endpointResolver, stubBehavior: stubBehavior, networkActivityClosure: networkActivityClosure)
+    override public init(endpointClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping, endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEnpointResolution, stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil) {
+        super.init(endpointClosure: endpointClosure, endpointResolver: endpointResolver, stubBehavior: stubBehavior, networkActivityClosure: networkActivityClosure)
     }
 
     /// Designated request-making method.

--- a/Moya/ReactiveCocoa/Moya+ReactiveCocoa.swift
+++ b/Moya/ReactiveCocoa/Moya+ReactiveCocoa.swift
@@ -8,7 +8,7 @@ public class ReactiveMoyaProvider<T where T: MoyaTarget>: MoyaProvider<T> {
     public var inflightRequests = Dictionary<Endpoint<T>, RACSignal>()
 
     /// Initializes a reactive provider.
-    override public init(endpointsClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping(), endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEnpointResolution(), stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil) {
+    override public init(endpointsClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping, endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEnpointResolution, stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil) {
         super.init(endpointsClosure: endpointsClosure, endpointResolver: endpointResolver, stubBehavior: stubBehavior, networkActivityClosure: networkActivityClosure)
     }
 

--- a/Moya/ReactiveCocoa/Moya+ReactiveCocoa.swift
+++ b/Moya/ReactiveCocoa/Moya+ReactiveCocoa.swift
@@ -8,8 +8,8 @@ public class ReactiveMoyaProvider<T where T: MoyaTarget>: MoyaProvider<T> {
     public var inflightRequests = Dictionary<Endpoint<T>, RACSignal>()
 
     /// Initializes a reactive provider.
-    override public init(endpointsClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping(), endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEnpointResolution(), stubResponses: Bool = false, stubBehavior: MoyaStubbedBehavior = MoyaProvider.DefaultStubBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil) {
-        super.init(endpointsClosure: endpointsClosure, endpointResolver: endpointResolver, stubResponses: stubResponses, networkActivityClosure: networkActivityClosure)
+    override public init(endpointsClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping(), endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEnpointResolution(), stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil) {
+        super.init(endpointsClosure: endpointsClosure, endpointResolver: endpointResolver, networkActivityClosure: networkActivityClosure)
     }
 
     /// Designated request-making method.

--- a/Moya/RxSwift/Moya+RxSwift.swift
+++ b/Moya/RxSwift/Moya+RxSwift.swift
@@ -8,8 +8,8 @@ public class RxMoyaProvider<T where T: MoyaTarget>: MoyaProvider<T> {
     public var inflightRequests = Dictionary<Endpoint<T>, Observable<MoyaResponse>>()
 
     /// Initializes a reactive provider.
-    override public init(endpointsClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping(), endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEnpointResolution(), stubResponses: Bool = false, stubBehavior: MoyaStubbedBehavior = MoyaProvider.DefaultStubBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil) {
-        super.init(endpointsClosure: endpointsClosure, endpointResolver: endpointResolver, stubResponses: stubResponses, stubBehavior: stubBehavior, networkActivityClosure: networkActivityClosure)
+    override public init(endpointsClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping(), endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEnpointResolution(), stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil) {
+        super.init(endpointsClosure: endpointsClosure, endpointResolver: endpointResolver, stubBehavior: stubBehavior, networkActivityClosure: networkActivityClosure)
     }
 
     /// Designated request-making method.

--- a/Moya/RxSwift/Moya+RxSwift.swift
+++ b/Moya/RxSwift/Moya+RxSwift.swift
@@ -8,8 +8,8 @@ public class RxMoyaProvider<T where T: MoyaTarget>: MoyaProvider<T> {
     public var inflightRequests = Dictionary<Endpoint<T>, Observable<MoyaResponse>>()
 
     /// Initializes a reactive provider.
-    override public init(endpointsClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping, endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEnpointResolution, stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil) {
-        super.init(endpointsClosure: endpointsClosure, endpointResolver: endpointResolver, stubBehavior: stubBehavior, networkActivityClosure: networkActivityClosure)
+    override public init(endpointClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping, endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEnpointResolution, stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil) {
+        super.init(endpointClosure: endpointClosure, endpointResolver: endpointResolver, stubBehavior: stubBehavior, networkActivityClosure: networkActivityClosure)
     }
 
     /// Designated request-making method.

--- a/Moya/RxSwift/Moya+RxSwift.swift
+++ b/Moya/RxSwift/Moya+RxSwift.swift
@@ -8,7 +8,7 @@ public class RxMoyaProvider<T where T: MoyaTarget>: MoyaProvider<T> {
     public var inflightRequests = Dictionary<Endpoint<T>, Observable<MoyaResponse>>()
 
     /// Initializes a reactive provider.
-    override public init(endpointsClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping(), endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEnpointResolution(), stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil) {
+    override public init(endpointsClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping, endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEnpointResolution, stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil) {
         super.init(endpointsClosure: endpointsClosure, endpointResolver: endpointResolver, stubBehavior: stubBehavior, networkActivityClosure: networkActivityClosure)
     }
 

--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -23,7 +23,7 @@ There are two ways that you interact with Endpoints.
 The first might resemble the following:
 
 ```swift
-let endpointsClosure = { (target: MyTarget) -> Endpoint<MyTarget> in
+let endpointClosure = { (target: MyTarget) -> Endpoint<MyTarget> in
     let url = target.baseURL.URLByAppendingPathComponent(target.path).absoluteString
     return Endpoint(URL: url!, sampleResponse: .Success(200, {target.sampleData}), method: target.method, parameters: target.parameters)
 }
@@ -46,12 +46,12 @@ From Target to Endpoint
 
 By default, `Endpoint` instances use the `.URL` type parameter encoding. You
 can specify how you'd like to encode parameters on a target-by-target basis in
-the `endpointsClosure` using the optional `parameterEncoding` parameter of the
-`Endpoint` initializer in your `endpointsClosure` when setting up the provider. 
+the `endpointClosure` using the optional `parameterEncoding` parameter of the
+`Endpoint` initializer in your `endpointClosure` when setting up the provider. 
 
 There are four parameter encoding types: `.URL`, `.JSON`, `.PropertyList`, and
 `.Custom`, which map directly to the corresponding types in Alamofire. These 
-are also configured in the `endpointsClosure` of the provider. Usually you just
+are also configured in the `endpointClosure` of the provider. Usually you just
 want `.URL`, but you can use whichever you like. These are mapped directly to
 the [Alamofire parameter encodings](https://github.com/Alamofire/Alamofire/blob/3d271dbbf12e104ab1373bff36c91c5ecbcc3890/Source/ParameterEncoding.swift#L47).
 
@@ -60,7 +60,7 @@ may wish to set our application name in the HTTP header fields for server-side
 analytics. 
 
 ```swift
-let endpointsClosure = { (target: MyTarget) -> Endpoint<MyTarget> in
+let endpointClosure = { (target: MyTarget) -> Endpoint<MyTarget> in
     let endpoint: Endpoint<MyTarget> = Endpoint<MyTarget>(URL: url(target), sampleResponse: .Success(200, {target.sampleData}), method: target.method, parameters: target.parameters)
     return endpoint.endpointByAddingHTTPHeaderFields(["APP_NAME": "MY_AWESOME_APP"])
 }
@@ -70,10 +70,10 @@ This also means that you can provide additional parameters to some or all of
 your endpoints. For example, say that there is an authentication token we need
 for  all values of the hypothetical `MyTarget` target, with the exception of the 
 target that actually does the authentication. We could construct an 
-`endpointsClosure` resembling the following. 
+`endpointClosure` resembling the following. 
 
 ```swift
-let endpointsClosure = { (target: MyTarget) -> Endpoint<MyTarget> in
+let endpointClosure = { (target: MyTarget) -> Endpoint<MyTarget> in
     let endpoint: Endpoint<MyTarget> = Endpoint<MyTarget>(URL: url(target), sampleResponse: .Success(200, {target.sampleData}), method: target.method, parameters: target.parameters)
 
     // Sign all non-authenticating requests
@@ -112,7 +112,7 @@ As we mentioned earlier, the purpose of this library is not really to provide a
 coding framework with which to access the network – that's Alamofire's job. 
 Instead, Moya is about a way to frame your thoughts about network access and 
 provide compile-time checking of well-defined network targets. You've already 
-seen how to map targets into endpoints using the `endpointsClosure` parameter
+seen how to map targets into endpoints using the `endpointClosure` parameter
 of the `MoyaProvider` initializer. That let you create an `Endpoint` instance
 that Moya will use to reason about the network API call. At some point, that
 `Endpoint` must be resolved into an actual `NSURLRequest` to give to Alamofire. 

--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -119,7 +119,7 @@ that Moya will use to reason about the network API call. At some point, that
 That's what the `endpointResolver` parameter is for. 
 
 The `endpointResolver` is an optional, last-minute way to modify the request 
-that hits the network. It has a default value of `DefaultEnpointResolution()`, 
+that hits the network. It has a default value of `MoyaProvider.DefaultEnpointResolution`, 
 which simply uses the `urlRequest` property of the `Endpoint` instance. 
 
 This closure receives an `Endpoint` instance and is responsible for returning a

--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -66,7 +66,7 @@ public func url(route: MoyaTarget) -> String {
     return route.baseURL.URLByAppendingPathComponent(route.path).absoluteString
 }
 
-let endpointsClosure = { (target: GitHub, method: Moya.Method, parameters: [String: AnyObject]) -> Endpoint<GitHub> in
+let endpointClosure = { (target: GitHub, method: Moya.Method, parameters: [String: AnyObject]) -> Endpoint<GitHub> in
     return Endpoint<GitHub>(URL: url(target), method: method, parameters: parameters, sampleResponse: .Success(200, target.sampleData))
 }
 ```
@@ -85,7 +85,7 @@ closure, it'll be executed at each invocation of the API, so you could do
 whatever you want. Say you want to test errors, too.
 
 ```swift
-let failureEndpointsClosure = { (target: GitHub, method: Moya.Method, parameters: [String: AnyObject]) -> Endpoint<GitHub> in
+let failureEndpointClosure = { (target: GitHub, method: Moya.Method, parameters: [String: AnyObject]) -> Endpoint<GitHub> in
     let sampleResponse = { () -> (EndpointSampleResponse) in
         if sendErrors {
             return .Error(404, NSError())
@@ -108,7 +108,7 @@ Great, now we're all set. Just need to create our provider.
 var provider: MoyaProvider<GitHub>!
 
 // Create this instance at app launch
-let provider = MoyaProvider(endpointsClosure: endpointsClosure)
+let provider = MoyaProvider(endpointClosure: endpointClosure)
 ```
 
 Neato. Now how do we make a request?

--- a/docs/Providers.md
+++ b/docs/Providers.md
@@ -36,18 +36,18 @@ endpoints closure, which is responsible for mapping a value of your enum to a
 concrete `Endpoint` instance. Let's take a look at what one might look like. 
 
 ```swift
-let endpointsClosure = { (target: MyTarget) -> Endpoint<MyTarget> in
+let endpointClosure = { (target: MyTarget) -> Endpoint<MyTarget> in
     let url = target.baseURL.URLByAppendingPathComponent(target.path).absoluteString
     return Endpoint(URL: url!, sampleResponse: .Success(200, {target.sampleData}), method: target.method, parameters: target.parameters)
 }
-let provider = MoyaProvider(endpointsClosure: endpointsClosure)
+let provider = MoyaProvider(endpointClosure: endpointClosure)
 ```
 
 Notice that we don't have to specify the generic type in the `MoyaProvider` 
 initializer anymore, since Swift will infer it from the type of our
-`endpointsClosure`. Neat!
+`endpointClosure`. Neat!
 
-This `endpointsClosure` is about as simple as you can get. It's actually the 
+This `endpointClosure` is about as simple as you can get. It's actually the 
 default implementation, too, stored in `MoyaProvider.DefaultEndpointMapping`. 
 Check out the [Endpoints](Endpoints.md) documentation for more on _why_ you 
 might want to customize this.

--- a/docs/Providers.md
+++ b/docs/Providers.md
@@ -55,14 +55,39 @@ The next optional initializer parameter is `endpointResolver`, which resolves
 an `Endpoint` to an actual `NSURLRequest`. Again, check out the [Endpoints](Endpoints.md) 
 documentation for how and why you'd do this. 
 
-The third optional parameter, `stubResponses`, is very straightforward: 
-should the provider access the API or should it return the stubbed data? 
+The next option is to provide a `stubBehavior` of either `.NotStubbing` (the 
+default), `.Immediate` or `.Delayed(seconds)`, where you can delay the stubbed 
+request  by a certain number of seconds. For example, `.Delayed(0.2)` would delay
+every stubbed request. This can be good for simulating network delays in unit tests. 
 
-Another option is to provide a `stubBehavior` of either `.Immediate` (the
-default) or `.Delayed(seconds)`, where you can delay every stubbed request 
-by a certain number of seconds. For example, `.Delayed(0.2)` would delay
-every stubbed request. This can be good for simulating network delays in
-unit tests. Don't worry – Moya doesn't delay actual requests!
+What's nice is that if you need to stub some requests differently than others,
+you can use your own closure. 
+
+```swift
+let provider = MoyaProvider<MyTarget>(stubBehavior: { (target: MyTarget) -> Moya.StubbedBehavior in
+	switch target {
+		/* Return something different based on the target. */
+	}
+}
+```
+})
+
+But usually you want the same stubbing behaviour for all your targets. There are
+three class methods on `MoyaProvider` you can use instead.
+
+```swift
+MoyaProvider.NoStubbingBehavior
+MoyaProvider.ImmediateStubbingBehaviour
+MoyaProvider.DelayedStubbingBehaviour(seconds)
+```
+
+So, in the above example, if you wanted immediate stubbing behaviour for all 
+targets, either of the following would work.
+
+```swift
+let provider = MoyaProvider<MyTarget>(stubBehavior: { (_: MyTarget) -> Moya.StubbedBehavior in return .Immediate })
+let provider = MoyaProvider<MyTarget>(stubBehavior: MoyaProvider.ImmediateStubbingBehaviour)
+```
 
 Finally, there's the `networkActivityClosure` parameter. This is a closure
 that you can provide to be notified whenever a network request begins or

--- a/docs/Providers.md
+++ b/docs/Providers.md
@@ -47,9 +47,10 @@ Notice that we don't have to specify the generic type in the `MoyaProvider`
 initializer anymore, since Swift will infer it from the type of our
 `endpointsClosure`. Neat!
 
-This `endpointsClosure` is about as simple as you can get. Check out the
-[Endpoints](Endpoints.md) documentation for more on _why_ you might want
-to do this.
+This `endpointsClosure` is about as simple as you can get. It's actually the 
+default implementation, too, stored in `MoyaProvider.DefaultEndpointMapping`. 
+Check out the [Endpoints](Endpoints.md) documentation for more on _why_ you 
+might want to customize this.
 
 The next optional initializer parameter is `endpointResolver`, which resolves
 an `Endpoint` to an actual `NSURLRequest`. Again, check out the [Endpoints](Endpoints.md) 


### PR DESCRIPTION
Removes `stubResponses` in favour of a new `StubbingBehavior` (it would be weird before if you said "don't stub responses", but also "delay my stubbed responses"). 

Also redefines types of `DefaultEndpointMapping` and `DefaultEnpointResolution` class functions so you don't invoke them to get the direct values anymore.

Old:

```swift
MoyaProvider<MyTarget>(endpointResolver: MoyaProvider.DefaultEndpointResolution())
```

vs. new:

```swift
MoyaProvider<MyTarget>(endpointResolver: MoyaProvider.DefaultEndpointResolution)
```

Fixes #137.
Fixes #142.