### PR TITLE
ReactiveCocoa version issue on pod install

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ lines to your Podfile:
 pod 'Moya'
 
 # Include the following only if you want to use ReactiveCocoa extensions with Moya
-pod 'ReactiveCocoa', '3.0.0-beta.6'
+pod 'ReactiveCocoa', '3.0-beta.6'
 pod 'Moya/Reactive'
 ```
 


### PR DESCRIPTION
I tried to set up a project with Moya + ReactiveCocoa and got this error when following the README and typing "pod install":
```
Analyzing dependencies
[!] Unable to satisfy the following requirements:

- `ReactiveCocoa (= 3.0.0-beta.6)` required by `Podfile
```
Then I changed it to '3.0-beta.6' because I saw it in your .podspec and it worked:
```
Analyzing dependencies
Downloading dependencies
Using Alamofire (1.2.3)
Installing Box (1.2.2)
Installing Moya 1.1.1 (was 1.1.1)
Installing ReactiveCocoa (3.0-beta.6)
Installing Result (0.4.4)
Generating Pods project
Integrating client project
```
I guess that this is the correct way to do it, otherwise just ignore this request.

Moya seems very interesting, thanks! :+1: 