### PR TITLE
use ~> 3.0 to pick a version of ReactiveCocoa in Cartfile

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "Alamofire/Alamofire" ~> 1.2.0
-github "ReactiveCocoa/ReactiveCocoa" "v3.0-beta.6"
+github "ReactiveCocoa/ReactiveCocoa" ~> 3.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "Alamofire/Alamofire" "1.2.2"
+github "Alamofire/Alamofire" "1.2.3"
 github "robrix/Box" "1.2.2"
-github "antitypical/Result" "0.4.3"
-github "ReactiveCocoa/ReactiveCocoa" "b15798ae4f6386b8461b3b06f49908f2009a28ce"
+github "antitypical/Result" "0.4.4"
+github "ReactiveCocoa/ReactiveCocoa" "v3.0-beta.8"


### PR DESCRIPTION
fixes #153