### PR TITLE
Change ReactiveCocoa subspec to ReactiveCocoa/Core

### DIFF
--- a/Moya.podspec
+++ b/Moya.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
   s.subspec "ReactiveCocoa" do |ss|
     ss.source_files = "Moya/ReactiveCocoa/*.swift"
     ss.dependency "Moya/ReactiveCore"
-    ss.dependency "ReactiveCocoa", "3.0-beta.6"
+    ss.dependency "ReactiveCocoa/Core", "3.0-beta.6"
   end
 
   s.subspec "RxSwift" do |ss|

--- a/README.md
+++ b/README.md
@@ -67,8 +67,7 @@ lines to your Podfile:
 pod 'Moya'
 
 # Include the following only if you want to use ReactiveCocoa extensions with Moya
-pod 'ReactiveCocoa', '3.0-beta.6'
-pod 'Moya/Reactive'
+pod 'Moya/ReactiveCocoa'
 ```
 
 Then run `pod install`. 


### PR DESCRIPTION
The ReactiveCocoa subspec only depends on `ReactiveCocoa/Core`. ReactiveCocoa's default subspec is the larger `ReactiveCocoa/UI`