### PR TITLE
Fixes for swift 2.0 in Xcode 7.3

### DIFF
--- a/Moya.podspec
+++ b/Moya.podspec
@@ -32,12 +32,12 @@ Pod::Spec.new do |s|
   s.subspec "ReactiveCocoa" do |ss|
     ss.source_files = "Moya/ReactiveCocoa/*.swift"
     ss.dependency "Moya/ReactiveCore"
-    ss.dependency "ReactiveCocoa", "3.0-beta.6"
+    ss.dependency "ReactiveCocoa"
   end
 
   s.subspec "RxSwift" do |ss|
     ss.source_files = "Moya/RxSwift/*.swift"
     ss.dependency "Moya/ReactiveCore"
-    ss.dependency "RxSwift", "1.4"
+    ss.dependency "RxSwift", "~> 1.7"
   end
 end

--- a/Moya/Endpoint.swift
+++ b/Moya/Endpoint.swift
@@ -24,10 +24,10 @@ public class Endpoint<T> {
     public let sampleResponse: EndpointSampleResponse
     public let parameters: [String: AnyObject]
     public let parameterEncoding: Moya.ParameterEncoding
-    public let httpHeaderFields: [String: AnyObject]
+    public let httpHeaderFields: [String: String]
     
     /// Main initializer for Endpoint.
-    public init(URL: String, sampleResponse: EndpointSampleResponse, method: Moya.Method = Moya.Method.GET, parameters: [String: AnyObject] = [String: AnyObject](), parameterEncoding: Moya.ParameterEncoding = .URL, httpHeaderFields: [String: AnyObject] = [String: AnyObject]()) {
+    public init(URL: String, sampleResponse: EndpointSampleResponse, method: Moya.Method = Moya.Method.GET, parameters: [String: AnyObject] = [String: AnyObject](), parameterEncoding: Moya.ParameterEncoding = .URL, httpHeaderFields: [String: String] = [String: String]()) {
         self.URL = URL
         self.sampleResponse = sampleResponse
         self.method = method
@@ -47,8 +47,8 @@ public class Endpoint<T> {
     }
     
     /// Convenience method for creating a new Endpoint with the same properties as the receiver, but with added HTTP header fields.
-    public func endpointByAddingHTTPHeaderFields(httpHeaderFields: [String: AnyObject]) -> Endpoint<T> {
-        var newHTTPHeaderFields = self.httpHeaderFields ?? [String: AnyObject]()
+    public func endpointByAddingHTTPHeaderFields(httpHeaderFields: [String: String]) -> Endpoint<T> {
+        var newHTTPHeaderFields = self.httpHeaderFields ?? [String: String]()
         for (key, value) in httpHeaderFields {
             newHTTPHeaderFields[key] = value
         }
@@ -60,9 +60,10 @@ public class Endpoint<T> {
 /// Extension for converting an extension into an NSURLRequest.
 extension Endpoint {
     public var urlRequest: NSURLRequest {
-        var request: NSMutableURLRequest = NSMutableURLRequest(URL: NSURL(string: URL)!)
+        let request: NSMutableURLRequest = NSMutableURLRequest(URL: NSURL(string: URL)!)
         request.HTTPMethod = method.method().rawValue
         request.allHTTPHeaderFields = httpHeaderFields
+        httpHeaderFields
         return parameterEncoding.parameterEncoding().encode(request, parameters: parameters).0
     }
 }

--- a/Moya/Moya.swift
+++ b/Moya/Moya.swift
@@ -136,7 +136,7 @@ public class MoyaProvider<T: MoyaTarget> {
 
     public class func DefaultEndpointMapping(target: T) -> Endpoint<T> {
         let url = target.baseURL.URLByAppendingPathComponent(target.path).absoluteString
-        return Endpoint(URL: url!, sampleResponse: .Success(200, {target.sampleData}), method: target.method, parameters: target.parameters)
+        return Endpoint(URL: url, sampleResponse: .Success(200, {target.sampleData}), method: target.method, parameters: target.parameters)
     }
 
     public class func DefaultEnpointResolution(endpoint: Endpoint<T>) -> NSURLRequest {
@@ -163,8 +163,8 @@ private extension MoyaProvider {
 
         // We need to keep a reference to the closure without a reference to ourself.
         let networkActivityCallback = networkActivityClosure
-        let request = Alamofire.Manager.sharedInstance.request(request)
-            .response { (request: NSURLRequest, response: NSHTTPURLResponse?, data: AnyObject?, error: NSError?) -> () in
+        
+        let request = Alamofire.Manager.sharedInstance.request(request).response { (request: NSURLRequest?, response: NSHTTPURLResponse?, data: AnyObject?, error: NSError?) -> () in
                 networkActivityCallback?(change: .Ended)
 
                 // Alamofire always sends the data param as an NSData? type, but we'll

--- a/Moya/ReactiveCore/MoyaResponse.swift
+++ b/Moya/ReactiveCore/MoyaResponse.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public class MoyaResponse: NSObject, Printable, DebugPrintable {
+public class MoyaResponse: NSObject, CustomDebugStringConvertible {
     public let statusCode: Int
     public let data: NSData
     public let response: NSURLResponse?


### PR DESCRIPTION
I have looked at getting Moya (specifically for RxSwift) working with swift 2.0.
Using the new Xcode 7.3 beta and by totally ignoring ReactiveCocoa, I think I've managed to get Moya somewhat working.

It seems to be working well in my own project but I haven't got the Demo project and its tests working. I also had problems with ReactiveCocoa due to Carthage setup which I'm not very familiar with.

The main concern for me is the return defer in Moya+RxSwift.swift due to the changes which won't allow defer's to return.  I don't really see the need for a defer anyway so have simply replaced with a return closure.

Nonetheless, hopefully this might help with the migration over to 2.0